### PR TITLE
2 d cij bug

### DIFF
--- a/applications/cahnHilliard/.project
+++ b/applications/cahnHilliard/.project
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>main-Debug@cahnHilliard</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>[Targets]</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
+		</link>
+		<link>
+			<name>[Targets]/[exe] main</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/src/models/mechanics/anisotropy.h
+++ b/src/models/mechanics/anisotropy.h
@@ -70,9 +70,9 @@ void getCIJMatrix(elasticityModel model, double constants[], dealii::Table<2, do
       CIJ[0][0]=constants[0]; //C11
       CIJ[1][1]=constants[1]; //C22
       CIJ[2][2]=constants[2]; //C33
-      CIJ[0][1]=constants[3]; //C12
-      CIJ[0][2]=constants[4]; //C13
-      CIJ[1][2]=constants[5]; //C23
+      CIJ[0][1]=CIJ[1][0]=constants[3]; //C12
+      CIJ[0][2]=CIJ[2][0]=constants[4]; //C13
+      CIJ[1][2]=CIJ[2][1]=constants[5]; //C23
       break;
     }
     default:{


### PR DESCRIPTION
I believe there is a bug in how the Cij tensor is formed for 2D anisotropic calculations (in anisotropy.h). In previous versions of the code (e.g. Nov 26, 2014), all of the elements of Cij are nonzero. In the current code, the (1,0), (2,0), and (2,1) elements aren't assigned.