### PR TITLE
Allow subdivided domain

### DIFF
--- a/applications/allenCahn/parameters.h
+++ b/applications/allenCahn/parameters.h
@@ -7,6 +7,9 @@
 #define spanZ 100.0
 
 //define mesh parameters
+#define subdivisionsX 1
+#define subdivisionsY 1
+#define subdivisionsZ 1
 #define refineFactor 7
 #define finiteElementDegree 1
 

--- a/applications/betaPrimePrecipitateEvolution/main.cc
+++ b/applications/betaPrimePrecipitateEvolution/main.cc
@@ -33,7 +33,7 @@ public:
   double value (const Point<dim> &p, const unsigned int component = 0) const
   {
     //set result equal to the structural order paramter initial condition
-    double dx=spanX/std::pow(2.0,refineFactor);
+    double dx=spanX/((double) subdivisionsX)/std::pow(2.0,refineFactor);
     double r=0.0;
 #if problemDIM==2
     if (index==1){

--- a/applications/betaPrimePrecipitateEvolution/parameters.h
+++ b/applications/betaPrimePrecipitateEvolution/parameters.h
@@ -11,6 +11,9 @@
 #define spanZ 100.0
 
 //define mesh parameters
+#define subdivisionsX 1
+#define subdivisionsY 1
+#define subdivisionsZ 1
 #define refineFactor 7
 #define finiteElementDegree 1
 

--- a/applications/cahnHilliard/.project
+++ b/applications/cahnHilliard/.project
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>main-Debug@cahnHilliard</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>[Targets]</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
+		</link>
+		<link>
+			<name>[Targets]/[exe] main</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/applications/cahnHilliard/parameters.h
+++ b/applications/cahnHilliard/parameters.h
@@ -7,6 +7,9 @@
 #define spanZ 100.0
 
 //define mesh parameters
+#define subdivisionsX 1
+#define subdivisionsY 1
+#define subdivisionsZ 1
 #define refineFactor 7
 #define finiteElementDegree 1
 

--- a/applications/coupledCahnHilliardAllenCahn/main.cc
+++ b/applications/coupledCahnHilliardAllenCahn/main.cc
@@ -17,7 +17,7 @@ public:
   double value (const Point<dim> &p, const unsigned int component = 0) const
   {
     //return the value of the initial concentration field at point p 
-    double dx=spanX/std::pow(2.0,refineFactor);
+    double dx=spanX/((double) subdivisionsX)/std::pow(2.0,refineFactor);
     double r=0.0;
 #if problemDIM==1
     r=p[0];
@@ -43,7 +43,7 @@ public:
   double value (const Point<dim> &p, const unsigned int component = 0) const
   {
     //return the value of the initial order parameter field at point p 
-    double dx=spanX/std::pow(2.0,refineFactor);
+	  double dx=spanX/((double) subdivisionsX)/std::pow(2.0,refineFactor);
     double r=0.0;
 #if problemDIM==1
   r=p[0];

--- a/applications/coupledCahnHilliardAllenCahn/parameters.h
+++ b/applications/coupledCahnHilliardAllenCahn/parameters.h
@@ -7,6 +7,9 @@
 #define spanZ 100.0
 
 //define mesh parameters
+#define subdivisionsX 1
+#define subdivisionsY 1
+#define subdivisionsZ 1
 #define refineFactor 7
 #define finiteElementDegree 1
 

--- a/applications/coupledCahnHilliardMechanics/parameters.h
+++ b/applications/coupledCahnHilliardMechanics/parameters.h
@@ -7,6 +7,9 @@
 #define spanZ 100.0
 
 //define mesh parameters
+#define subdivisionsX 1
+#define subdivisionsY 1
+#define subdivisionsZ 1
 #define refineFactor 7
 #define finiteElementDegree 1
 

--- a/applications/fickianDiffusion/parameters.h
+++ b/applications/fickianDiffusion/parameters.h
@@ -7,6 +7,9 @@
 #define spanZ 1.0
 
 //define mesh parameters
+#define subdivisionsX 1
+#define subdivisionsY 1
+#define subdivisionsZ 1
 #define refineFactor 7
 #define finiteElementDegree 1
 

--- a/applications/mechanics/parameters.h
+++ b/applications/mechanics/parameters.h
@@ -7,6 +7,9 @@
 #define spanZ 100.0
 
 //define mesh parameters
+#define subdivisionsX 1
+#define subdivisionsY 1
+#define subdivisionsZ 1
 #define refineFactor 4
 #define finiteElementDegree 1
 

--- a/src/matrixfree/init.cc
+++ b/src/matrixfree/init.cc
@@ -20,7 +20,6 @@
 		   subdivisions.push_back(subdivisionsZ);
 	   }
    }
-   GridGenerator::subdivided_hyper_rectangle (triangulation, subdivisions, Point<dim>(), Point<dim>(spanX,spanY));
 
    pcout << "creating problem mesh...\n";
  #if problemDIM==3

--- a/src/matrixfree/init.cc
+++ b/src/matrixfree/init.cc
@@ -12,13 +12,23 @@
    computing_timer.enter_section("matrixFreePDE: initialization"); 
 
    //creating mesh
+   std::vector<unsigned int> subdivisions;
+   subdivisions.push_back(subdivisionsX);
+   if (dim>1){
+	   subdivisions.push_back(subdivisionsY);
+	   if (dim>2){
+		   subdivisions.push_back(subdivisionsZ);
+	   }
+   }
+   GridGenerator::subdivided_hyper_rectangle (triangulation, subdivisions, Point<dim>(), Point<dim>(spanX,spanY));
+
    pcout << "creating problem mesh...\n";
  #if problemDIM==3
-   GridGenerator::hyper_rectangle (triangulation, Point<dim>(), Point<dim>(spanX,spanY,spanZ));
+   GridGenerator::subdivided_hyper_rectangle (triangulation, subdivisions, Point<dim>(), Point<dim>(spanX,spanY,spanZ));
 #elif problemDIM==2
-   GridGenerator::hyper_rectangle (triangulation, Point<dim>(), Point<dim>(spanX,spanY));
+   GridGenerator::subdivided_hyper_rectangle (triangulation, subdivisions, Point<dim>(), Point<dim>(spanX,spanY));
  #elif problemDIM==1
-   GridGenerator::hyper_rectangle (triangulation, Point<dim>(), Point<dim>(spanX));
+   GridGenerator::subdivided_hyper_rectangle (triangulation, subdivisions, Point<dim>(), Point<dim>(spanX));
  #endif
    triangulation.refine_global (refineFactor);
    //write out extends


### PR DESCRIPTION
I generalized the mesh generation to subdivided_hyper_rectangle. I added subdivisionX, subdivisionY, and subdivisionZ to each of the parameters files. For the main.cc files that calculate the grid spacing, I made the necessary modifications. If there are any other places in the code where the grid spacing is given, I didn't change it. (Are there?)