### PR TITLE
Fixed issues with nonuniform Dirichlet boundary conditions

### DIFF
--- a/src/matrixfree/init.cc
+++ b/src/matrixfree/init.cc
@@ -154,7 +154,7 @@ template <int dim, int degree>
          has_Dirichlet_BCs = false;
          for (unsigned int i=0; i<fields.size(); i++){
              for (unsigned int direction = 0; direction < 2*dim; direction++){
-                 if (userInputs.BC_list[i].var_BC_type[direction] == DIRICHLET){
+                 if (userInputs.BC_list[i].var_BC_type[direction] == DIRICHLET || userInputs.BC_list[i].var_BC_type[direction] == NON_UNIFORM_DIRICHLET){
                      has_Dirichlet_BCs = true;
                      break;
                  }

--- a/src/matrixfree/init.cc
+++ b/src/matrixfree/init.cc
@@ -150,16 +150,16 @@ template <int dim, int degree>
 		 // Get constraints for periodic BCs
 		 setPeriodicityConstraints(constraintsOther,dof_handler);
 
-         // Check if Dirichlet BCs are used
-         has_Dirichlet_BCs = false;
-         for (unsigned int i=0; i<fields.size(); i++){
-             for (unsigned int direction = 0; direction < 2*dim; direction++){
-                 if (userInputs.BC_list[i].var_BC_type[direction] == DIRICHLET || userInputs.BC_list[i].var_BC_type[direction] == NON_UNIFORM_DIRICHLET){
-                     has_Dirichlet_BCs = true;
-                     break;
-                 }
+     // Check if Dirichlet BCs are used
+     has_Dirichlet_BCs = false;
+     for (unsigned int i=0; i<userInputs.BC_list.size(); i++){
+         for (unsigned int direction = 0; direction < 2*dim; direction++){
+             if (userInputs.BC_list[i].var_BC_type[direction] == DIRICHLET || userInputs.BC_list[i].var_BC_type[direction] == NON_UNIFORM_DIRICHLET){
+                 has_Dirichlet_BCs = true;
+                 break;
              }
          }
+     }
 
 		 // Get constraints for Dirichlet BCs
 		 applyDirichletBCs();

--- a/src/matrixfree/solveIncrement.cc
+++ b/src/matrixfree/solveIncrement.cc
@@ -6,6 +6,9 @@
 //solve each time increment
 template <int dim, int degree>
 void MatrixFreePDE<dim,degree>::solveIncrement(bool skip_time_dependent){
+  
+    bool field_has_nonuniform_Dirichlet_BCs;
+    unsigned int starting_BC_list_index;
 
     //log time
     computing_timer.enter_section("matrixFreePDE: solveIncrements");
@@ -36,10 +39,62 @@ void MatrixFreePDE<dim,degree>::solveIncrement(bool skip_time_dependent){
                 solutionSet[fieldIndex]->local_element(dof)=			\
                 invM.local_element(dof%invM_size)*residualSet[fieldIndex]->local_element(dof);
             }
+          
             // Set the Dirichelet values (hanging node constraints don't need to be distributed every time step, only at output)
             if (has_Dirichlet_BCs){
+              
+                //TEMPORARY SECTION (Add to a method later)
+                //Check if any of the Dirichlet BCs if nonuniform
+                field_has_nonuniform_Dirichlet_BCs = false;
+              
+                // First, get the starting_BC_list_index for the current field
+                starting_BC_list_index = 0;
+                for (unsigned int i=0; i<currentFieldIndex; i++){
+                  
+                  if (userInputs.var_type[i] == SCALAR){
+                    starting_BC_list_index++;
+                  }
+                  else {
+                    starting_BC_list_index+=dim;
+                  }
+                }
+                //Checking for non-uniform Dirichlet BCs if the field is scalar
+                if (userInputs.var_type[currentFieldIndex] == SCALAR){
+                    for (unsigned int direction = 0; direction < 2*dim; direction++){
+                        if (userInputs.BC_list[starting_BC_list_index].var_BC_type[direction] == NON_UNIFORM_DIRICHLET){
+                          field_has_nonuniform_Dirichlet_BCs = true;
+                          break;
+                        }
+                    }
+                } else {
+                //Checking for non-uniform Dirichlet BCs if the field is nonscalar
+                    for (unsigned int direction = 0; direction < 2*dim; direction++){
+                       for (unsigned int component=0; component < dim; component++){
+                          if (userInputs.BC_list[starting_BC_list_index+component].var_BC_type[direction] == NON_UNIFORM_DIRICHLET){
+                            field_has_nonuniform_Dirichlet_BCs = true;
+                            break;
+                          }
+                       }
+                    }
+                }
+                // Apply non-uniform Dirlichlet_BCs to the current field
+                if (field_has_nonuniform_Dirichlet_BCs) {
+                    DoFHandler<dim>* dof_handler;
+                    dof_handler=dofHandlersSet_nonconst.at(currentFieldIndex);
+                    IndexSet* locally_relevant_dofs;
+                    locally_relevant_dofs=locally_relevant_dofsSet_nonconst.at(currentFieldIndex);
+                    locally_relevant_dofs->clear();
+                    DoFTools::extract_locally_relevant_dofs (*dof_handler, *locally_relevant_dofs);
+                    ConstraintMatrix *constraintsDirichlet;
+                    constraintsDirichlet=constraintsDirichletSet_nonconst.at(currentFieldIndex);
+                    constraintsDirichlet->clear(); constraintsDirichlet->reinit(*locally_relevant_dofs);
+                    applyDirichletBCs();
+                    constraintsDirichlet->close();
+                }
+                //Distribute for Uniform or Non-Uniform Dirichlet BCs
                 constraintsDirichletSet[fieldIndex]->distribute(*solutionSet[fieldIndex]);
             }
+          
             //computing_timer.enter_section("matrixFreePDE: updateExplicitGhosts");
             solutionSet[fieldIndex]->update_ghost_values();
             //computing_timer.exit_section("matrixFreePDE: updateExplicitGhosts");

--- a/tests/automatic_tests/test_results.txt
+++ b/tests/automatic_tests/test_results.txt
@@ -1571,3 +1571,32 @@ Time: 74.2514219284
  
 Tests Passed: 5/5
 --------------------------------------------------------- 
+--------------------------------------------------------- 
+Unit test on 2023-05-03 13:41
+--------------------------------------------------------- 
+Unit Tests Passed: 24/24
+--------------------------------------------------------- 
+Regression test on 2023-05-03 13:41
+--------------------------------------------------------- 
+Application: allenCahn 
+Result: Pass 
+Time: 19.7699818611 
+ 
+Application: cahnHilliard 
+Result: Pass 
+Time: 165.700474024 
+ 
+Application: CHAC_anisotropyRegularized 
+Result: Pass 
+Time: 55.0869970322 
+ 
+Application: coupledCahnHilliardAllenCahn 
+Result: Pass 
+Time: 160.280323029 
+ 
+Application: precipitateEvolution 
+Result: Pass 
+Time: 81.8718562126 
+ 
+Tests Passed: 5/5
+--------------------------------------------------------- 


### PR DESCRIPTION
1) Expanded the criteria to consider that the system has Dirichlet boundary conditions (BC) to when they are nonuniform. Previously, if only nonuniform Dirichlet conditions were set for a field. The code did not recognize them as Dirichlet BC and missed setting them.

2) Fixed an incomplete loop to detect Dirichlet BC in /src/matrixfree/init.cc. Previously the loop was over field variables. Currently it is over boundaries.

3) Fixed bug that caused time-dependent Dirichlet boundary conditions to be updated except when mesh refinement was applied.