### PR TITLE
Increased auxiliary term performance

### DIFF
--- a/src/matrixfree/solveIncrement.cc
+++ b/src/matrixfree/solveIncrement.cc
@@ -441,13 +441,11 @@ void MatrixFreePDE<dim,degree>::solveIncrement(bool skip_time_dependent){
                 }
 
                 //check if solution is nan
-                if (currentIncrement%userInputs.skip_print_steps==0){
-                    if (!numbers::is_finite(solutionSet[fieldIndex]->l2_norm())){
-                        snprintf(buffer, sizeof(buffer), "ERROR: field '%s' solution is NAN. exiting.\n\n",
-                        fields[fieldIndex].name.c_str());
-                        pcout<<buffer;
-                        exit(-1);
-                    }
+                if (!numbers::is_finite(solutionSet[fieldIndex]->l2_norm())){
+                    snprintf(buffer, sizeof(buffer), "ERROR: field '%s' solution is NAN. exiting.\n\n",
+                    fields[fieldIndex].name.c_str());
+                    pcout<<buffer;
+                    exit(-1);
                 }
 
             }

--- a/src/matrixfree/solveIncrement.cc
+++ b/src/matrixfree/solveIncrement.cc
@@ -399,6 +399,8 @@ void MatrixFreePDE<dim,degree>::solveIncrement(bool skip_time_dependent){
                             constraintsDirichletSet[fieldIndex]->distribute(*solutionSet[fieldIndex]);
                         }
 
+                        solutionSet[fieldIndex]->update_ghost_values();
+
                         // Print update to screen
                         if (currentIncrement%userInputs.skip_print_steps==0){
                             snprintf(buffer, sizeof(buffer), "field '%2s' [auxiliary solve]: current solution: %12.6e, current residual:%12.6e\n", \

--- a/src/matrixfree/solveIncrement.cc
+++ b/src/matrixfree/solveIncrement.cc
@@ -345,8 +345,59 @@ void MatrixFreePDE<dim,degree>::solveIncrement(bool skip_time_dependent){
                         }
 
                         // Set the Dirichelet values (hanging node constraints don't need to be distributed every time step, only at output)
-                        constraintsDirichletSet[fieldIndex]->distribute(*solutionSet[fieldIndex]);
-                        solutionSet[fieldIndex]->update_ghost_values();
+                        if (has_Dirichlet_BCs){
+              
+                            //TEMPORARY SECTION (Add to a method later)
+                            //Check if any of the Dirichlet BCs if nonuniform
+                            field_has_nonuniform_Dirichlet_BCs = false;
+                        
+                            // First, get the starting_BC_list_index for the current field
+                            starting_BC_list_index = 0;
+                            for (unsigned int i=0; i<currentFieldIndex; i++){
+                            
+                            if (userInputs.var_type[i] == SCALAR){
+                                starting_BC_list_index++;
+                            }
+                            else {
+                                starting_BC_list_index+=dim;
+                            }
+                            }
+                            //Checking for non-uniform Dirichlet BCs if the field is scalar
+                            if (userInputs.var_type[currentFieldIndex] == SCALAR){
+                                for (unsigned int direction = 0; direction < 2*dim; direction++){
+                                    if (userInputs.BC_list[starting_BC_list_index].var_BC_type[direction] == NON_UNIFORM_DIRICHLET){
+                                    field_has_nonuniform_Dirichlet_BCs = true;
+                                    break;
+                                    }
+                                }
+                            } else {
+                            //Checking for non-uniform Dirichlet BCs if the field is nonscalar
+                                for (unsigned int direction = 0; direction < 2*dim; direction++){
+                                for (unsigned int component=0; component < dim; component++){
+                                    if (userInputs.BC_list[starting_BC_list_index+component].var_BC_type[direction] == NON_UNIFORM_DIRICHLET){
+                                        field_has_nonuniform_Dirichlet_BCs = true;
+                                        break;
+                                    }
+                                }
+                                }
+                            }
+                            // Apply non-uniform Dirlichlet_BCs to the current field
+                            if (field_has_nonuniform_Dirichlet_BCs) {
+                                DoFHandler<dim>* dof_handler;
+                                dof_handler=dofHandlersSet_nonconst.at(currentFieldIndex);
+                                IndexSet* locally_relevant_dofs;
+                                locally_relevant_dofs=locally_relevant_dofsSet_nonconst.at(currentFieldIndex);
+                                locally_relevant_dofs->clear();
+                                DoFTools::extract_locally_relevant_dofs (*dof_handler, *locally_relevant_dofs);
+                                AffineConstraints<double> *constraintsDirichlet;
+                                constraintsDirichlet=constraintsDirichletSet_nonconst.at(currentFieldIndex);
+                                constraintsDirichlet->clear(); constraintsDirichlet->reinit(*locally_relevant_dofs);
+                                applyDirichletBCs();
+                                constraintsDirichlet->close();
+                            }
+                            //Distribute for Uniform or Non-Uniform Dirichlet BCs
+                            constraintsDirichletSet[fieldIndex]->distribute(*solutionSet[fieldIndex]);
+                        }
 
                         // Print update to screen
                         if (currentIncrement%userInputs.skip_print_steps==0){
@@ -388,11 +439,13 @@ void MatrixFreePDE<dim,degree>::solveIncrement(bool skip_time_dependent){
                 }
 
                 //check if solution is nan
-                if (!numbers::is_finite(solutionSet[fieldIndex]->l2_norm())){
-                    snprintf(buffer, sizeof(buffer), "ERROR: field '%s' solution is NAN. exiting.\n\n",
-                    fields[fieldIndex].name.c_str());
-                    pcout<<buffer;
-                    exit(-1);
+                if (currentIncrement%userInputs.skip_print_steps==0){
+                    if (!numbers::is_finite(solutionSet[fieldIndex]->l2_norm())){
+                        snprintf(buffer, sizeof(buffer), "ERROR: field '%s' solution is NAN. exiting.\n\n",
+                        fields[fieldIndex].name.c_str());
+                        pcout<<buffer;
+                        exit(-1);
+                    }
                 }
 
             }


### PR DESCRIPTION
1. Auxiliary terms have dirichlet boundaries applied every increment regardless of input boundary conditions
2. NaN solutions are checked every increment  

Fixing these to more closely resemble the process for explicit terms decreases computation time greatly. These changes have been tested on the Cahn-Hilliard app to produce identical results with an ~25% decrease in computation time.