### PR TITLE
Added input parameter options for nucleation

### DIFF
--- a/include/userInputParameters.h
+++ b/include/userInputParameters.h
@@ -144,10 +144,14 @@ public:
 	bool nucleation_occurs;
 	std::vector<unsigned int> nucleating_variable_indices;
 	std::vector<unsigned int> nucleation_need_value;
-
+	bool evolution_before_nucleation;
+	//Declare later
+	//bool multiple_nuclei_per_order_parameter;
 	double min_distance_between_nuclei; // Only enforced for nuclei placed during the same time step
 	double nucleation_order_parameter_cutoff;
 	unsigned int steps_between_nucleation_attempts;
+	double nucleation_start_time;
+	double nucleation_end_time;
 
     // Grain remapping parameters
     bool grain_remapping_activated;

--- a/src/inputFileReader/inputFileReader.cc
+++ b/src/inputFileReader/inputFileReader.cc
@@ -363,10 +363,15 @@ void inputFileReader::declare_parameters(dealii::ParameterHandler & parameter_ha
     }
 
     // Declare the nucleation parameters
+    parameter_handler.declare_entry("Enable evolution before nucleation","false",dealii::Patterns::Bool(),"Whether variable fields evolve before the first nucleus appears.");  
+    //Implement later
+    //parameter_handler.declare_entry("Allow multiple nuclei per order parameter","true",dealii::Patterns::Bool(),"Whether multiple nucleation events can occur within an order parameter.");
     parameter_handler.declare_entry("Minimum allowed distance between nuclei","-1",dealii::Patterns::Double(),"The minimum allowed distance between nuclei placed during the same time step.");
     parameter_handler.declare_entry("Order parameter cutoff value","0.01",dealii::Patterns::Double(),"Order parameter cutoff value for nucleation (when the sum of all order parameters is above this value, no nucleation is attempted).");
     parameter_handler.declare_entry("Time steps between nucleation attempts","100",dealii::Patterns::Integer(),"The number of time steps between nucleation attempts.");
-
+    parameter_handler.declare_entry("Nucleation start time","0.0",dealii::Patterns::Double(),"The time at which nucleation starts.");
+    parameter_handler.declare_entry("Nucleation end time","1.0e10",dealii::Patterns::Double(),"The time after which no nucleation occurs.");
+    
     for (unsigned int i=0; i<var_types.size(); i++){
         if (var_nucleates.at(i)){
             std::string nucleation_text = "Nucleation parameters: ";

--- a/src/userInputParameters/userInputParameters.cc
+++ b/src/userInputParameters/userInputParameters.cc
@@ -360,8 +360,13 @@ userInputParameters<dim>::userInputParameters(inputFileReader & input_file_reade
     else if (nucleation_parameters_list.size() > 1) {
         min_distance_between_nuclei = 2.0 * (*(max_element(nucleation_parameters_list[0].semiaxes.begin(),nucleation_parameters_list[0].semiaxes.end())));
     }
+    evolution_before_nucleation = parameter_handler.get_bool("Enable evolution before nucleation");
+    //Implement multiple order parameter nucleation later
+    //multiple_nuclei_per_order_parameter = parameter_handler.get_bool("Allow multiple nuclei per order parameter");
     nucleation_order_parameter_cutoff = parameter_handler.get_double("Order parameter cutoff value");
     steps_between_nucleation_attempts = parameter_handler.get_integer("Time steps between nucleation attempts");
+    nucleation_start_time = parameter_handler.get_double("Nucleation start time");
+    nucleation_end_time = parameter_handler.get_double("Nucleation end time");
 
     // Load the grain remapping parameters
     grain_remapping_activated = parameter_handler.get_bool("Activate grain reassignment");


### PR DESCRIPTION
For the nucleation section of parameters.prm, options were added to:
- Enable evolution of field variables before the first nucleus appears
- Set a nucleation start time
- Set a nucleation end time