### PR TITLE
Minor simplifications for dirichlet BCs in implicit solves

### DIFF
--- a/src/matrixfree/computeLHS.cc
+++ b/src/matrixfree/computeLHS.cc
@@ -21,12 +21,8 @@ void MatrixFreePDE<dim,degree>::vmult (vectorType &dst, const vectorType &src) c
       matrixFreeObject.cell_loop (&MatrixFreePDE<dim,degree>::getLaplaceLHS, this, dst, src2, true);
   }
 
-  //Account for Dirichlet BC's (essentially copy dirichlet DOF values present in src to dst, although it is unclear why the constraints can't just be distributed here)
-  for (std::map<types::global_dof_index, double>::const_iterator it=valuesDirichletSet[currentFieldIndex]->begin(); it!=valuesDirichletSet[currentFieldIndex]->end(); ++it){
-    if (dst.in_local_range(it->first)){
-      dst(it->first) = src(it->first); //*jacobianDiagonal(it->first);
-    }
-  }
+  //Account for Dirichlet BC's
+  constraintsDirichletSet[currentFieldIndex]->distribute(dst);
 
   //end log
   computing_timer.leave_subsection("matrixFreePDE: computeLHS");

--- a/src/matrixfree/solveIncrement.cc
+++ b/src/matrixfree/solveIncrement.cc
@@ -156,16 +156,9 @@ void MatrixFreePDE<dim,degree>::solveIncrement(bool skip_time_dependent){
                         pcout<<buffer;
                     }
 
-                    dealii::LinearAlgebra::distributed::Vector<double> solution_diff = *solutionSet[fieldIndex];
-
-                    //apply Dirichlet BC's
-                    // Loops through all DoF to which ones have Dirichlet BCs applied, replace the ones that do with the Dirichlet value
+                    //apply Dirichlet BC'se
                     // This clears the residual where we want to apply Dirichlet BCs, otherwise the solver sees a positive residual
-                    for (std::map<types::global_dof_index, double>::const_iterator it=valuesDirichletSet[fieldIndex]->begin(); it!=valuesDirichletSet[fieldIndex]->end(); ++it){
-                        if (residualSet[fieldIndex]->in_local_range(it->first)){
-                            (*residualSet[fieldIndex])(it->first) = 0.0;
-                        }
-                    }
+                    constraintsDirichletSet[fieldIndex]->set_zero(*residualSet[fieldIndex]);
 
                     //solver controls
                     double tol_value;


### PR DESCRIPTION
1. Constrained DoF in the residual set can be set to zero with `set_zero`
2. Dirichlet constraints can be distributed with `distribute`