### PR TITLE
invM for scalar & vector fields

### DIFF
--- a/include/matrixFreePDE.h
+++ b/include/matrixFreePDE.h
@@ -90,7 +90,7 @@ class MatrixFreePDE:public Subscriptor
    * other custom selected options specifically to help with unit tests, and should not be called
    * in any of the physical models.
    */
-  void initForTests();
+  void initForTests(std::vector<Field<dim>> _fields);
 
   /**
    * This method implements the time stepping algorithm and invokes the solveIncrement() method.

--- a/include/matrixFreePDE.h
+++ b/include/matrixFreePDE.h
@@ -200,8 +200,10 @@ class MatrixFreePDE:public Subscriptor
    *Refer to deal.ii documentation of MatrixFree<dim> class for details.
    */
   MatrixFree<dim,double>               matrixFreeObject;
-  /*Vector to store the inverse of the mass matrix diagonal. Due to the choice of spectral elements with Guass-Lobatto quadrature, the mass matrix is diagonal.*/
-  vectorType                           invM;
+  /*Vector to store the inverse of the mass matrix diagonal for scalar fields. Due to the choice of spectral elements with Guass-Lobatto quadrature, the mass matrix is diagonal.*/
+  vectorType                           invMscalar;
+  /*Vector to store the inverse of the mass matrix diagonal for vector fields. Due to the choice of spectral elements with Guass-Lobatto quadrature, the mass matrix is diagonal.*/
+  vectorType                           invMvector;
   /*Vector to store the solution increment. This is a temporary vector used during implicit solves of the Elliptic fields.*/
   vectorType                           dU_vector, dU_scalar;
 
@@ -210,6 +212,9 @@ class MatrixFreePDE:public Subscriptor
   unsigned int currentFieldIndex;
   /*Method to compute the inverse of the mass matrix*/
   void computeInvM();
+
+  /*Method to compute an explicit timestep*/
+  void updateExplicitSolution(unsigned int fieldIndex);
 
   /*AMR methods*/
   /**

--- a/src/matrixfree/initForTests.cc
+++ b/src/matrixfree/initForTests.cc
@@ -6,14 +6,10 @@
 template <int dim, int degree>
  void MatrixFreePDE<dim,degree>::initForTests(){
 
-   //creating mesh
+    // creating mesh
    std::vector<unsigned int> subdivisions;
-   subdivisions.push_back(10);
-   if (dim>1){
-     subdivisions.push_back(10);
-     if (dim>2){
-       subdivisions.push_back(10);
-     }
+   for (unsigned int i = 0; i < dim; i++){
+      subdivisions.push_back(10);
    }
 
    if (dim == 3){

--- a/src/matrixfree/invM.cc
+++ b/src/matrixfree/invM.cc
@@ -6,31 +6,53 @@
 //compute inverse of the diagonal mass matrix and store in vector invM
 template <int dim, int degree>
 void MatrixFreePDE<dim,degree>::computeInvM(){
-	//initialize  invM
-	bool invMInitialized=false;
-	unsigned int parabolicFieldIndex=0;
+	//Find invM indices by looping through all fields for the first field of that type 
+	//(e.g., the index of the first explicit time dependent scalar field)
+	//This has to be done for all types of fields.
+
+	//This only has to be done when the fields are first initialized. It's redundant
+	//for any reinitialized like in adaptive mesh refinement (AMR). Hopefully the
+	//performance is fine
+	bool invMscalarFound=false;
+	bool invMvectorFound=false;
+
+	unsigned int parabolicScalarFieldIndex=0;
+	unsigned int parabolicVectorFieldIndex=0;
+
 	for(unsigned int fieldIndex=0; fieldIndex<fields.size(); fieldIndex++){
 		if (fields[fieldIndex].pdetype==EXPLICIT_TIME_DEPENDENT || fields[fieldIndex].pdetype==AUXILIARY){
-			matrixFreeObject.initialize_dof_vector (invM, fieldIndex);
-			parabolicFieldIndex=fieldIndex;
-			invMInitialized=true;
-			break;
+			if (fields[fieldIndex].type==SCALAR && !invMscalarFound){
+				parabolicScalarFieldIndex=fieldIndex;
+				invMscalarFound=true;
+				continue;
+			}
+			else if (fields[fieldIndex].type==VECTOR && !invMvectorFound){
+				parabolicVectorFieldIndex=fieldIndex;
+				invMvectorFound=true;
+				continue;
+			}
 		}
 	}
-	//check if invM initialized
-	if (!invMInitialized){
-		pcout << "matrixFreePDE.h: no PARABOLIC field... hence setting parabolicFieldIndex to 0 and marching ahead withn invM computation\n";
-		//exit(-1);
+
+	//Check if invM has been found. If not, print an "error" message
+	if (!invMscalarFound){
+		pcout << "matrixFreePDE.h: no PARABOLIC scalar field... hence setting parabolicScalarFieldIndex to 0 and marching ahead withn invM computation\n";
+	}
+	else if (!invMvectorFound){
+		pcout << "matrixFreePDE.h: no PARABOLIC vector field... hence setting parabolicVectorFieldIndex to 0 and marching ahead withn invM computation\n";
 	}
 
-	//compute invM
-	matrixFreeObject.initialize_dof_vector (invM, parabolicFieldIndex);
-	invM=0.0;
+	//Initialize invM and clear its values
+	matrixFreeObject.initialize_dof_vector (invMscalar, parabolicScalarFieldIndex);
+	invMscalar=0.0;
+	matrixFreeObject.initialize_dof_vector (invMvector, parabolicVectorFieldIndex);
+	invMvector=0.0;
 
-	//select gauss lobatto quadrature points which are suboptimal but give diagonal M
-	if (fields[parabolicFieldIndex].type==SCALAR){
+	//Compute mass matrix for the given type of quadrature. Selecting gauss lobatto 
+	//quadrature points which are suboptimal but give diagonal M
+	if (fields[parabolicScalarFieldIndex].type==SCALAR){
 		VectorizedArray<double> one = make_vectorized_array (1.0);
-		FEEvaluation<dim,degree> fe_eval(matrixFreeObject, parabolicFieldIndex);
+		FEEvaluation<dim,degree> fe_eval(matrixFreeObject, parabolicScalarFieldIndex);
 		const unsigned int n_q_points = fe_eval.n_q_points;
 		for (unsigned int cell=0; cell<matrixFreeObject.n_cell_batches(); ++cell){
 			fe_eval.reinit(cell);
@@ -38,16 +60,16 @@ void MatrixFreePDE<dim,degree>::computeInvM(){
 				fe_eval.submit_value(one,q);
 			}
 			fe_eval.integrate (true,false);
-			fe_eval.distribute_local_to_global (invM);
+			fe_eval.distribute_local_to_global (invMscalar);
 		}
 	}
-	else {
+	if (fields[parabolicVectorFieldIndex].type==VECTOR){
 		dealii::Tensor<1, dim, dealii::VectorizedArray<double> > oneV;
 		for (unsigned int i=0;i<dim;i++){
 			oneV[i] = 1.0;
 		}
 
-		FEEvaluation<dim,degree,degree+1,dim> fe_eval(matrixFreeObject, parabolicFieldIndex);
+		FEEvaluation<dim,degree,degree+1,dim> fe_eval(matrixFreeObject, parabolicVectorFieldIndex);
 
 		const unsigned int n_q_points = fe_eval.n_q_points;
 		for (unsigned int cell=0; cell<matrixFreeObject.n_cell_batches(); ++cell){
@@ -56,15 +78,15 @@ void MatrixFreePDE<dim,degree>::computeInvM(){
 				fe_eval.submit_value(oneV,q);
 			}
 			fe_eval.integrate (true,false);
-			fe_eval.distribute_local_to_global (invM);
+			fe_eval.distribute_local_to_global (invMvector);
 		}
 	}
 
+	invMscalar.compress(VectorOperation::add);
+	invMvector.compress(VectorOperation::add);
 
-	invM.compress(VectorOperation::add);
-
-    // Calculate the volume of the smallest cell to prevent a non-zero value of invM being
-    // confused for a near zero value (which can happen if the domain size is 1e-6 or below)
+    //Calculate the volume of the smallest cell to prevent a non-zero value of invM being
+    //confused for a near zero value (which can happen if the domain size is 1e-6 or below)
     std::vector<double> min_element_length;
     for (unsigned int d=0; d<dim; d++){
         int num_elements = userInputs.subdivisions.at(d)*dealii::Utilities::fixed_power<2>(userInputs.max_refinement_level);
@@ -72,20 +94,35 @@ void MatrixFreePDE<dim,degree>::computeInvM(){
     }
     double min_cell_volume = std::accumulate(begin(min_element_length), end(min_element_length), 1, std::multiplies<double>());
 
-	//invert mass matrix diagonal elements
+	//Invert scalar mass matrix diagonal elements
 #if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-        for (unsigned int k=0; k<invM.local_size(); ++k){
+        for (unsigned int k=0; k<invMscalar.local_size(); ++k){
 #else
-	for (unsigned int k=0; k<invM.locally_owned_size(); ++k){
+	for (unsigned int k=0; k<invMscalar.locally_owned_size(); ++k){
 #endif
-		if (std::abs(invM.local_element(k))>1.0e-15 * min_cell_volume){
-			invM.local_element(k) = 1./invM.local_element(k);
+		if (std::abs(invMscalar.local_element(k))>1.0e-15 * min_cell_volume){
+			invMscalar.local_element(k) = 1./invMscalar.local_element(k);
 		}
 		else{
-			invM.local_element(k) = 0;
+			invMscalar.local_element(k) = 0;
 		}
 	}
-	pcout << "computed mass matrix (using FE space for field: " << parabolicFieldIndex << ")\n";
+	pcout << "computed scalar mass matrix (using FE space for field: " << parabolicScalarFieldIndex << ")\n";
+
+	//Invert vector mass matrix diagonal elements
+#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
+        for (unsigned int k=0; k<invMvector.local_size(); ++k){
+#else
+	for (unsigned int k=0; k<invMvector.locally_owned_size(); ++k){
+#endif
+		if (std::abs(invMvector.local_element(k))>1.0e-15 * min_cell_volume){
+			invMvector.local_element(k) = 1./invMvector.local_element(k);
+		}
+		else{
+			invMvector.local_element(k) = 0;
+		}
+	}
+	pcout << "computed vector mass matrix (using FE space for field: " << parabolicVectorFieldIndex << ")\n";
 }
 
 #include "../../include/matrixFreePDE_template_instantiations.h"

--- a/src/matrixfree/outputResults.cc
+++ b/src/matrixfree/outputResults.cc
@@ -28,20 +28,21 @@ void MatrixFreePDE<dim,degree>::outputResults() {
 
   // Test section for outputting postprocessed fields
   // Currently there are hacks in place, using the matrixFreeObject, invM, constraints, and DoFHandler as the primary variables
+  //Currently only works for scalar fields. Require separate loop for vector-type post process fields
   if (userInputs.postProcessingRequired){
 	  std::vector<vectorType*> postProcessedSet;
       computePostProcessedFields(postProcessedSet);
 #if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-	  unsigned int invM_size = invM.local_size();
+	  unsigned int invM_size = invMscalar.local_size();
 	  for(unsigned int fieldIndex=0; fieldIndex<postProcessedSet.size(); fieldIndex++){
 		  for (unsigned int dof=0; dof<postProcessedSet[fieldIndex]->local_size(); ++dof){
 #else
-          unsigned int invM_size = invM.locally_owned_size();
+          unsigned int invM_size = invMscalar.locally_owned_size();
           for(unsigned int fieldIndex=0; fieldIndex<postProcessedSet.size(); fieldIndex++){
                   for (unsigned int dof=0; dof<postProcessedSet[fieldIndex]->locally_owned_size(); ++dof){
 #endif
 			  postProcessedSet[fieldIndex]->local_element(dof)=			\
-					  invM.local_element(dof%invM_size)*postProcessedSet[fieldIndex]->local_element(dof);
+					  invMscalar.local_element(dof%invM_size)*postProcessedSet[fieldIndex]->local_element(dof);
 
 		  }
 		  constraintsOtherSet[0]->distribute(*postProcessedSet[fieldIndex]);

--- a/src/matrixfree/solveIncrement.cc
+++ b/src/matrixfree/solveIncrement.cc
@@ -32,18 +32,7 @@ void MatrixFreePDE<dim,degree>::solveIncrement(bool skip_time_dependent){
         //Parabolic (first order derivatives in time) fields
         if (fields[fieldIndex].pdetype==EXPLICIT_TIME_DEPENDENT && !skip_time_dependent){
 
-            // Explicit-time step each DOF
-            // Takes advantage of knowledge that the length of solutionSet and residualSet is an integer multiple of the length of invM for vector variables
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-            unsigned int invM_size = invM.local_size();
-            for (unsigned int dof=0; dof<solutionSet[fieldIndex]->local_size(); ++dof){
-#else
-            unsigned int invM_size = invM.locally_owned_size();
-            for (unsigned int dof=0; dof<solutionSet[fieldIndex]->locally_owned_size(); ++dof){
-#endif
-                solutionSet[fieldIndex]->local_element(dof)=			\
-                invM.local_element(dof%invM_size)*residualSet[fieldIndex]->local_element(dof);
-            }
+            updateExplicitSolution(fieldIndex);
           
             // Set the Dirichelet values (hanging node constraints don't need to be distributed every time step, only at output)
             if (has_Dirichlet_BCs){
@@ -385,18 +374,7 @@ void MatrixFreePDE<dim,degree>::solveIncrement(bool skip_time_dependent){
                             }
                         }
 
-                        // Explicit-time step each DOF
-                        // Takes advantage of knowledge that the length of solutionSet and residualSet is an integer multiple of the length of invM for vector variables
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-                        unsigned int invM_size = invM.local_size();
-                        for (unsigned int dof=0; dof<solutionSet[fieldIndex]->local_size(); ++dof){
-#else
-                        unsigned int invM_size = invM.locally_owned_size();
-                        for (unsigned int dof=0; dof<solutionSet[fieldIndex]->locally_owned_size(); ++dof){
-#endif
-                            solutionSet[fieldIndex]->local_element(dof)=			\
-                            invM.local_element(dof%invM_size)*residualSet[fieldIndex]->local_element(dof);
-                        }
+                        updateExplicitSolution(fieldIndex);
 
                         // Set the Dirichelet values (hanging node constraints don't need to be distributed every time step, only at output)
                         if (has_Dirichlet_BCs){
@@ -513,6 +491,37 @@ void MatrixFreePDE<dim,degree>::solveIncrement(bool skip_time_dependent){
     //log time
     computing_timer.leave_subsection("matrixFreePDE: solveIncrements");
 
+}
+
+//Explicit time step for matrixfree solve
+template <int dim, int degree>
+void MatrixFreePDE<dim,degree>::updateExplicitSolution(unsigned int fieldIndex){
+    // Explicit-time step each DOF
+    // Takes advantage of knowledge that the length of solutionSet and residualSet is an integer multiple of the length of invM for vector variables
+    if (fields[fieldIndex].type==SCALAR){
+#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
+        unsigned int invM_size = invMscalar.local_size();
+        for (unsigned int dof=0; dof<solutionSet[fieldIndex]->local_size(); ++dof){
+#else
+        unsigned int invM_size = invMscalar.locally_owned_size();
+        for (unsigned int dof=0; dof<solutionSet[fieldIndex]->locally_owned_size(); ++dof){
+#endif
+            solutionSet[fieldIndex]->local_element(dof)=			\
+            invMscalar.local_element(dof%invM_size)*residualSet[fieldIndex]->local_element(dof);
+        }
+    }
+    else if (fields[fieldIndex].type==VECTOR){
+#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
+        unsigned int invM_size = invMvector.local_size();
+        for (unsigned int dof=0; dof<solutionSet[fieldIndex]->local_size(); ++dof){
+#else
+        unsigned int invM_size = invMvector.locally_owned_size();
+        for (unsigned int dof=0; dof<solutionSet[fieldIndex]->locally_owned_size(); ++dof){
+#endif
+            solutionSet[fieldIndex]->local_element(dof)=			\
+            invMvector.local_element(dof%invM_size)*residualSet[fieldIndex]->local_element(dof);
+        }
+    }
 }
 
 #include "../../include/matrixFreePDE_template_instantiations.h"

--- a/tests/unit_tests/test_invM.h
+++ b/tests/unit_tests/test_invM.h
@@ -12,16 +12,16 @@ class testInvM: public MatrixFreePDE<dim,degree>
 	  //init the MatrixFreePDE class for testing
 	  this->initForTests();
 
-	  //call computeInvM()
-	  this->computeInvM();
-	  invMNorm=this->invMscalar.l2_norm();
+      // call computeInvM()
+      this->computeInvM();
+      invMNormscalar = this->invMscalar.l2_norm();
+    };
+    ~testInvM()
+    {
+        this->matrixFreeObject.clear();
+    };
 
-  };
-  ~testInvM(){
-      this->matrixFreeObject.clear();
-  };
-
-  double invMNorm;
+  double invMNormscalar;
 
   void setBCs(){};
 
@@ -62,12 +62,14 @@ template <int dim,typename T>
 	//userInputParameters userInputs;
 	//userInputs.loadUserInput();
 
-    testInvM<dim,1> test(userInputs);
-	//check invM norm
-	if ((test.invMNorm - 1700.0) < 1.0e-10) {pass=true;}
-	char buffer[100];
-	snprintf(buffer, sizeof(buffer), "Test result for 'computeInvM' in   %u dimension(s): %u\n", dim, pass);
-	std::cout << buffer;
+    testInvM<dim, 1> test(userInputs);
+    // check invM norm
+    if (std::abs(test.invMNormscalar - 1700.0) < 1.0e-10) {
+        pass = true;
+    }
+    char buffer[100];
+    snprintf(buffer, sizeof(buffer), "Test result for 'computeInvM' in   %u dimension(s): %u\n", dim, pass);
+    std::cout << buffer;
 
 	return pass;
 }

--- a/tests/unit_tests/test_invM.h
+++ b/tests/unit_tests/test_invM.h
@@ -5,23 +5,31 @@ class testInvM: public MatrixFreePDE<dim,degree>
  public:
   testInvM(userInputParameters<dim> _userInputs): MatrixFreePDE<dim,degree>(_userInputs) {
 
-	  // Initialize the test field object (needed for computeInvM())
-	  Field<dim> test_field(SCALAR,EXPLICIT_TIME_DEPENDENT,"c");
-	  this->fields.push_back(test_field);
+    // Initialize the scalar test field object (needed for computeInvM())
+    Field<dim> scalar_test_field(SCALAR,EXPLICIT_TIME_DEPENDENT,"c");
+    this->fields.push_back(scalar_test_field);
 
-	  //init the MatrixFreePDE class for testing
-	  this->initForTests();
+    // Initialize the vector test field object (needed for computeInvM())
+    Field<dim> vector_test_field(VECTOR,EXPLICIT_TIME_DEPENDENT,"c");
+    this->fields.push_back(vector_test_field);
 
-      // call computeInvM()
-      this->computeInvM();
-      invMNormscalar = this->invMscalar.l2_norm();
-    };
-    ~testInvM()
-    {
-        this->matrixFreeObject.clear();
-    };
+    //init the MatrixFreePDE class for testing
+    this->initForTests(this->fields);
+
+    //call computeInvM()
+    this->computeInvM();
+    invMNormscalar = this->invMscalar.l2_norm();
+    invMNormvector = this->invMvector.l2_norm();
+    
+  };
+  ~testInvM()
+  {
+    this->matrixFreeObject.clear();
+  };
 
   double invMNormscalar;
+
+  double invMNormvector;
 
   void setBCs(){};
 
@@ -55,21 +63,41 @@ class testInvM: public MatrixFreePDE<dim,degree>
 
 template <int dim,typename T>
   bool unitTest<dim,T>::test_computeInvM(int argc, char** argv, userInputParameters<dim> userInputs){
-  	bool pass = false;
+  	
+    
+  bool pass = false;
+  bool pass_subtest1 = false;
+  bool pass_subtest2 = false;
+
+  char buffer[100];
 	std::cout << "\nTesting 'computeInvM' in " << dim << " dimension(s)...'" << std::endl;
 
 	//create test problem class object
 	//userInputParameters userInputs;
 	//userInputs.loadUserInput();
+  
+  testInvM<dim, 1> test(userInputs);
 
-    testInvM<dim, 1> test(userInputs);
-    // check invM norm
-    if (std::abs(test.invMNormscalar - 1700.0) < 1.0e-10) {
-        pass = true;
-    }
-    char buffer[100];
-    snprintf(buffer, sizeof(buffer), "Test result for 'computeInvM' in   %u dimension(s): %u\n", dim, pass);
-    std::cout << buffer;
+  //Subtest 1 - check invMscalar norm
+  if (std::abs(test.invMNormscalar - 1700.0) < 1.0e-10) {
+      pass_subtest1 = true;
+  }
+  snprintf(buffer, sizeof(buffer), "Subtest 1 scalar result for 'computeInvM' in %u dimension(s): %u\n", dim, pass_subtest1);
+	std::cout << buffer;
+
+  //Subtest 2 - check invMscalar norm
+  if (std::abs(test.invMNormvector - 2404.16305603426098) < 1.0e-10) {
+      pass_subtest2 = true;
+  }
+  snprintf(buffer, sizeof(buffer), "Subtest 2 vector result for 'computeInvM' in %u dimension(s): %u\n", dim, pass_subtest2);
+	std::cout << buffer;
+
+  //Check if all subtests passed
+  if (pass_subtest2&&pass_subtest1) {
+      pass=true;
+  }
+  snprintf(buffer, sizeof(buffer), "Test result for 'computeInvM' in %u dimension(s): %u\n", dim, pass);
+  std::cout << buffer;
 
 	return pass;
 }

--- a/tests/unit_tests/test_invM.h
+++ b/tests/unit_tests/test_invM.h
@@ -14,7 +14,7 @@ class testInvM: public MatrixFreePDE<dim,degree>
 
 	  //call computeInvM()
 	  this->computeInvM();
-	  invMNorm=this->invM.l2_norm();
+	  invMNorm=this->invMscalar.l2_norm();
 
   };
   ~testInvM(){

--- a/tests/unit_tests/test_setRigidBodyModeConstraints.h
+++ b/tests/unit_tests/test_setRigidBodyModeConstraints.h
@@ -5,7 +5,9 @@ class setRigidBodyModeConstraintsTest: public MatrixFreePDE<dim,degree>
 	public:
 	setRigidBodyModeConstraintsTest(userInputParameters<dim> _userInputs): MatrixFreePDE<dim,degree>(_userInputs) {
 		//init the MatrixFreePDE class for testing
-		this->initForTests();
+		Field<dim> scalar_test_field(SCALAR,EXPLICIT_TIME_DEPENDENT,"c");
+		this->fields.push_back(scalar_test_field);
+		this->initForTests(this->fields);
 	};
 	~setRigidBodyModeConstraintsTest(){
         this->matrixFreeObject.clear();


### PR DESCRIPTION
The inverted diagonal mass matrices (invM) for scalar and vector fields are different, so they must both be considered when updating the explicit solution. Previously, the type of the first occurring explicit field was used to calculate the invM. This led to issues if scalar & vector explicit fields were included (as only 1 field could be updated correctly).

Now, the scalar & vector invMs are calculated if there are scalar, vector, or scalar & vector fields whenever `computeInvM()` is called. 

I've also added a unit test for the invM of vector fields.