### PR TITLE
Added check for consistent periodic BCs and unspecified BCs

### DIFF
--- a/src/userInputParameters/load_BC_list.cc
+++ b/src/userInputParameters/load_BC_list.cc
@@ -1,102 +1,78 @@
+// ------------------------------------------------------------------------
+// Method to extract the list of boundary conditions from input parameters
+// and store them in BC_list object
+// ------------------------------------------------------------------------
+
 #include "../../include/userInputParameters.h"
 
-// ==========================================================================================
-// Method to extract the list of boundary conditions
-// ==========================================================================================
 template <int dim>
-void
-userInputParameters<dim>::load_BC_list(std::vector<std::string> list_of_BCs)
+void userInputParameters<dim>::load_BC_list(std::vector<std::string> list_of_BCs)
 {
-  // Load the BC information from the strings into a varBCs object
-  // Move this to a new method and write a unit test for it!!!!
+    // Loop over the list of boundary conditions specified in parameters
+    // and provided in the input list_of_BCs. Process the BCs and place
+    // them into the vector BC_list
+    std::vector<std::string> temp;
+    for (unsigned int i=0; i<list_of_BCs.size(); i++){
+        
+        // Ensure all variables have BCs specified in parameters.prm
+        if (list_of_BCs[i] == ""){
+            std::cout << "Error: Boundary condition not specified." << std::endl;
+            abort();
+        }
+        varBCs<dim> newBC;
+        temp = dealii::Utilities::split_string_list(list_of_BCs[i]);
 
-  std::vector<std::string> temp;
-
-  for (unsigned int i = 0; i < list_of_BCs.size(); i++)
-    {
-      varBCs<dim> newBC;
-      temp = dealii::Utilities::split_string_list(list_of_BCs[i]);
-
-      // If there is only one BC listed, make another dim*2-1 copies of it so
-      // that the same BC is applied for all boundaries
-      if (temp.size() == 1)
-        {
-          for (unsigned int boundary = 0; boundary < (dim * 2 - 1); boundary++)
-            {
-              temp.push_back(temp[0]);
+        // If there is only one BC listed, make another dim*2-1 copies of it so that 
+        // the same BC is applied for all boundaries
+        if (temp.size() == 1){
+            for (unsigned int boundary=0; boundary<(dim*2-1); boundary++){
+                temp.push_back(temp[0]);
             }
         }
 
-      // Load the BC for each boundary into 'newBC'
-      for (unsigned int i = 0; i < (2 * dim); i++)
-        {
-          if (boost::iequals(temp[i], "NATURAL"))
-            {
-              newBC.var_BC_type.push_back(NATURAL);
-              newBC.var_BC_val.push_back(0.0);
+        // Load the BC for each boundary into 'newBC'.
+        for (unsigned int j=0; j<(2*dim); j++){
+            if (boost::iequals(temp[j],"NATURAL")){
+                newBC.var_BC_type.push_back(NATURAL);
+                newBC.var_BC_val.push_back(0.0);
             }
-          else if (boost::iequals(temp[i], "PERIODIC"))
-            {
-              newBC.var_BC_type.push_back(PERIODIC);
-              newBC.var_BC_val.push_back(0.0);
+            else if (boost::iequals(temp[j],"PERIODIC")){
+                newBC.var_BC_type.push_back(PERIODIC);
+                newBC.var_BC_val.push_back(0.0);
             }
-          else if (boost::iequals(temp[i], "NON_UNIFORM_DIRICHLET"))
-            {
-              newBC.var_BC_type.push_back(NON_UNIFORM_DIRICHLET);
-              newBC.var_BC_val.push_back(0.0);
+            else if (boost::iequals(temp[j],"NON_UNIFORM_DIRICHLET")){
+                newBC.var_BC_type.push_back(NON_UNIFORM_DIRICHLET);
+                newBC.var_BC_val.push_back(0.0);
             }
-          else if (boost::iequals(temp[i].substr(0, 9), "DIRICHLET"))
-            {
-              newBC.var_BC_type.push_back(DIRICHLET);
-              std::string dirichlet_val = temp[i].substr(10, temp[i].size());
-              dirichlet_val             = dealii::Utilities::trim(dirichlet_val);
-              newBC.var_BC_val.push_back(
-                dealii::Utilities::string_to_double(dirichlet_val));
+            else if (boost::iequals(temp[j].substr(0,9),"DIRICHLET")){
+                newBC.var_BC_type.push_back(DIRICHLET);
+                std::string dirichlet_val = temp[j].substr(10,temp[j].size());
+                dirichlet_val = dealii::Utilities::trim(dirichlet_val);
+                newBC.var_BC_val.push_back(dealii::Utilities::string_to_double(dirichlet_val));
             }
-          else if (boost::iequals(temp[i].substr(0, 7), "NEUMANN"))
-            {
-              newBC.var_BC_type.push_back(NEUMANN);
-              std::string neumann_val = temp[i].substr(8, temp[i].size());
-              neumann_val             = dealii::Utilities::trim(neumann_val);
-              newBC.var_BC_val.push_back(
-                dealii::Utilities::string_to_double(neumann_val));
+            else if (boost::iequals(temp[j].substr(0,7),"NEUMANN")){
+                newBC.var_BC_type.push_back(NEUMANN);
+                std::string neumann_val = temp[j].substr(8,temp[j].size());
+                neumann_val = dealii::Utilities::trim(neumann_val);
+                newBC.var_BC_val.push_back(dealii::Utilities::string_to_double(neumann_val));
             }
-          else
-            {
-              std::cout << temp[i].substr(0, 8) << std::endl;
-              std::cout << "Error: Boundary conditions specified improperly."
-                        << std::endl;
-              abort();
+            else {
+                std::cout << temp[j].substr(0,8) << std::endl;
+                std::cout << "Error: Boundary conditions specified improperly." << std::endl;
+                abort();
+            }
+
+            // If periodic BCs are used, ensure they are applied on both sides of domain
+            if (j%2 == 0){
+                if ( (boost::iequals(temp[j],"PERIODIC") && !boost::iequals(temp[j+1],"PERIODIC")) || 
+                     (!boost::iequals(temp[j],"PERIODIC") && boost::iequals(temp[j+1],"PERIODIC")) ){
+                    std::cout << "Error: Periodic boundary condition must be specified on both sides of domain." << std::endl;
+                    abort();
+                }
             }
         }
-      BC_list.push_back(newBC);
-
-      // Validate input using something like this:
-      // try{
-      //     if ((BC_type_dim1_min == "PERIODIC") && (BC_type_dim1_max !=
-      //     "PERIODIC")){
-      //         throw 0;
-      //     }
-      //     if ((BC_type_dim2_min == "PERIODIC") && (BC_type_dim2_max !=
-      //     "PERIODIC")){
-      //         throw 0;
-      //     }
-      //     if ((BC_type_dim3_min == "PERIODIC") && (BC_type_dim3_max !=
-      //     "PERIODIC")){
-      //         throw 0;
-      //     }
-      // }
-      // catch (int e){
-      //     if (e == 0){
-      //         std::cout << "Error: For periodic BCs, both faces for a given
-      //         direction must be set as periodic. "
-      //                 "Please check the BCs that are set in ICs_and_BCs.h."
-      //                 << std::endl;
-      //     }
-      //     abort();
-      // }
+        // Append BCs for current field to total list 
+        BC_list.push_back(newBC);
     }
 }
-
-// Template instantiations
 #include "../../include/userInputParameters_template_instantiations.h"


### PR DESCRIPTION
This pull request addresses the following issues:

1) When a boundary condition for a field is unspecified in parameters.prm (i.e. it's completely missing or blank) a segmentation fault will occur

2) Periodic boundary conditions are currently allowed to be defined in an inconsistent manner (e.g. natural, periodic, natural natural)

**Changes:**
I made changes to load_BC_list.cc to give error messages for both of these cases. For issue (1) it checks if a BC list is empty, and for issue (2) it checks that 'periodic' is always specified in pairs for each direction.