### PR TITLE
Switching to range based loops

### DIFF
--- a/applications/CHiMaD_benchmark6b/customPDE.h
+++ b/applications/CHiMaD_benchmark6b/customPDE.h
@@ -205,9 +205,7 @@ customPDE<dim, degree>::makeTriangulation(
     }
 
   // Mark the boundaries
-  typename parallel::distributed::Triangulation<dim>::cell_iterator cell4 = tria.begin(),
-                                                                    endc4 = tria.end();
-  for (; cell4 != endc4; ++cell4)
+  for (const auto &cell4 : tria.active_cell_iterators())
     {
       // Mark all of the faces
       for (unsigned int face_number = 0; face_number < GeometryInfo<dim>::faces_per_cell;

--- a/applications/_nucleating_precipitates_MgRE/equations.h
+++ b/applications/_nucleating_precipitates_MgRE/equations.h
@@ -281,22 +281,19 @@ customPDE<dim, degree>::seedNucleus(
   dealii::AlignedVector<dealii::VectorizedArray<double>> &source_terms,
   dealii::VectorizedArray<double>                        &gamma) const
 {
-  for (typename std::vector<nucleus<dim>>::const_iterator thisNucleus =
-         this->nuclei.begin();
-       thisNucleus != this->nuclei.end();
-       ++thisNucleus)
+  for (const auto &thisNucleus : this->nuclei)
     {
-      if (thisNucleus->seededTime + thisNucleus->seedingTime > this->currentTime)
+      if (thisNucleus.seededTime + thisNucleus.seedingTime > this->currentTime)
         {
           // Calculate the weighted distance function to the order parameter
           // freeze boundary (weighted_dist = 1.0 on that boundary)
           dealii::VectorizedArray<double> weighted_dist =
             this->weightedDistanceFromNucleusCenter(
-              thisNucleus->center,
-              userInputs.get_nucleus_freeze_semiaxes(thisNucleus->orderParameterIndex),
-              userInputs.get_nucleus_rotation_matrix(thisNucleus->orderParameterIndex),
+              thisNucleus.center,
+              userInputs.get_nucleus_freeze_semiaxes(thisNucleus.orderParameterIndex),
+              userInputs.get_nucleus_rotation_matrix(thisNucleus.orderParameterIndex),
               q_point_loc,
-              thisNucleus->orderParameterIndex);
+              thisNucleus.orderParameterIndex);
 
           for (unsigned i = 0; i < gamma.size(); i++)
             {
@@ -306,13 +303,13 @@ customPDE<dim, degree>::seedNucleus(
 
                   // Seed a nucleus if it was added to the list of nuclei this
                   // time step
-                  if (thisNucleus->seedingTimestep == this->currentIncrement)
+                  if (thisNucleus.seedingTimestep == this->currentIncrement)
                     {
                       // Set the rotation matrix for this nucleus (two possible
                       // per order parameter)
                       dealii::Tensor<2, dim, double> nucleus_rot_matrix;
                       nucleus_rot_matrix = userInputs.get_nucleus_rotation_matrix(
-                        thisNucleus->orderParameterIndex);
+                        thisNucleus.orderParameterIndex);
 
                       // Find the weighted distance to the outer edge of the
                       // nucleus and use it to calculate the order parameter
@@ -323,26 +320,26 @@ customPDE<dim, degree>::seedNucleus(
                           q_point_loc_element(j) = q_point_loc(j)[i];
                         }
                       double r = this->weightedDistanceFromNucleusCenter(
-                        thisNucleus->center,
-                        userInputs.get_nucleus_semiaxes(thisNucleus->orderParameterIndex),
+                        thisNucleus.center,
+                        userInputs.get_nucleus_semiaxes(thisNucleus.orderParameterIndex),
                         nucleus_rot_matrix,
                         q_point_loc_element,
-                        thisNucleus->orderParameterIndex);
+                        thisNucleus.orderParameterIndex);
 
                       double avg_semiaxis = 0.0;
                       for (unsigned int j = 0; j < dim; j++)
                         {
-                          avg_semiaxis += thisNucleus->semiaxes[j];
+                          avg_semiaxis += thisNucleus.semiaxes[j];
                         }
                       avg_semiaxis /= dim;
 
-                      if (thisNucleus->orderParameterIndex == 1)
+                      if (thisNucleus.orderParameterIndex == 1)
                         {
                           source_terms[0][i] =
                             0.5 *
                             (1.0 - std::tanh(avg_semiaxis * (r - 1.0) / interface_coeff));
                         }
-                      else if (thisNucleus->orderParameterIndex == 2)
+                      else if (thisNucleus.orderParameterIndex == 2)
                         {
                           source_terms[1][i] =
                             0.5 *

--- a/applications/allenCahn_conserved/customPDE.h
+++ b/applications/allenCahn_conserved/customPDE.h
@@ -242,14 +242,11 @@ customPDE<dim, degree>::solveIncrement(bool skip_time_dependent)
                   //  applied, replace the ones that do with the Dirichlet value
                   //  This clears the residual where we want to apply Dirichlet
                   //  BCs, otherwise the solver sees a positive residual
-                  for (std::map<types::global_dof_index, double>::const_iterator it =
-                         this->valuesDirichletSet[fieldIndex]->begin();
-                       it != this->valuesDirichletSet[fieldIndex]->end();
-                       ++it)
+                  for (const auto &it : *this->valuesDirichletSet[fieldIndex])
                     {
-                      if (this->residualSet[fieldIndex]->in_local_range(it->first))
+                      if (this->residualSet[fieldIndex]->in_local_range(it.first))
                         {
-                          (*this->residualSet[fieldIndex])(it->first) = 0.0;
+                          (*this->residualSet[fieldIndex])(it.first) = 0.0;
                         }
                     }
 
@@ -341,16 +338,12 @@ customPDE<dim, degree>::solveIncrement(bool skip_time_dependent)
 
                               this->computeNonexplicitRHS();
 
-                              for (std::map<types::global_dof_index,
-                                            double>::const_iterator it =
-                                     this->valuesDirichletSet[fieldIndex]->begin();
-                                   it != this->valuesDirichletSet[fieldIndex]->end();
-                                   ++it)
+                              for (const auto &it : *this->valuesDirichletSet[fieldIndex])
                                 {
                                   if (this->residualSet[fieldIndex]->in_local_range(
-                                        it->first))
+                                        it.first))
                                     {
-                                      (*this->residualSet[fieldIndex])(it->first) = 0.0;
+                                      (*this->residualSet[fieldIndex])(it.first) = 0.0;
                                     }
                                 }
 

--- a/applications/nucleationModel/equations.cc
+++ b/applications/nucleationModel/equations.cc
@@ -133,21 +133,18 @@ customPDE<dim, degree>::seedNucleus(
   dealii::VectorizedArray<double>                           &source_term,
   dealii::VectorizedArray<double>                           &gamma) const
 {
-  for (typename std::vector<nucleus<dim>>::const_iterator thisNucleus =
-         this->nuclei.begin();
-       thisNucleus != this->nuclei.end();
-       ++thisNucleus)
+  for (const auto &thisNucleus : this->nuclei)
     {
-      if (thisNucleus->seededTime + thisNucleus->seedingTime > this->currentTime)
+      if (thisNucleus.seededTime + thisNucleus.seedingTime > this->currentTime)
         {
           // Calculate the weighted distance function to the order parameter
           // freeze boundary (weighted_dist = 1.0 on that boundary)
           dealii::VectorizedArray<double> weighted_dist =
             this->weightedDistanceFromNucleusCenter(
-              thisNucleus->center,
-              userInputs.get_nucleus_freeze_semiaxes(thisNucleus->orderParameterIndex),
+              thisNucleus.center,
+              userInputs.get_nucleus_freeze_semiaxes(thisNucleus.orderParameterIndex),
               q_point_loc,
-              thisNucleus->orderParameterIndex);
+              thisNucleus.orderParameterIndex);
 
           for (unsigned i = 0; i < gamma.size(); i++)
             {
@@ -157,7 +154,7 @@ customPDE<dim, degree>::seedNucleus(
 
                   // Seed a nucleus if it was added to the list of nuclei this
                   // time step
-                  if (thisNucleus->seedingTimestep == this->currentIncrement)
+                  if (thisNucleus.seedingTimestep == this->currentIncrement)
                     {
                       // Find the weighted distance to the outer edge of the
                       // nucleus and use it to calculate the order parameter
@@ -168,15 +165,15 @@ customPDE<dim, degree>::seedNucleus(
                           q_point_loc_element(j) = q_point_loc(j)[i];
                         }
                       double r = this->weightedDistanceFromNucleusCenter(
-                        thisNucleus->center,
-                        userInputs.get_nucleus_semiaxes(thisNucleus->orderParameterIndex),
+                        thisNucleus.center,
+                        userInputs.get_nucleus_semiaxes(thisNucleus.orderParameterIndex),
                         q_point_loc_element,
-                        thisNucleus->orderParameterIndex);
+                        thisNucleus.orderParameterIndex);
 
                       double avg_semiaxis = 0.0;
                       for (unsigned int j = 0; j < dim; j++)
                         {
-                          avg_semiaxis += thisNucleus->semiaxes[j];
+                          avg_semiaxis += thisNucleus.semiaxes[j];
                         }
                       avg_semiaxis /= dim;
 

--- a/applications/nucleationModel_preferential/equations.cc
+++ b/applications/nucleationModel_preferential/equations.cc
@@ -134,21 +134,18 @@ customPDE<dim, degree>::seedNucleus(
   dealii::VectorizedArray<double>                           &gamma) const
 {
   // Loop through all of the seeded nuclei
-  for (typename std::vector<nucleus<dim>>::const_iterator thisNucleus =
-         this->nuclei.begin();
-       thisNucleus != this->nuclei.end();
-       ++thisNucleus)
+  for (const auto &thisNucleus : this->nuclei)
     {
-      if (thisNucleus->seededTime + thisNucleus->seedingTime > this->currentTime)
+      if (thisNucleus.seededTime + thisNucleus.seedingTime > this->currentTime)
         {
           // Calculate the weighted distance function to the order parameter
           // freeze boundary (weighted_dist = 1.0 on that boundary)
           dealii::VectorizedArray<double> weighted_dist =
             this->weightedDistanceFromNucleusCenter(
-              thisNucleus->center,
-              userInputs.get_nucleus_freeze_semiaxes(thisNucleus->orderParameterIndex),
+              thisNucleus.center,
+              userInputs.get_nucleus_freeze_semiaxes(thisNucleus.orderParameterIndex),
               q_point_loc,
-              thisNucleus->orderParameterIndex);
+              thisNucleus.orderParameterIndex);
 
           for (unsigned i = 0; i < gamma.size(); i++)
             {
@@ -158,7 +155,7 @@ customPDE<dim, degree>::seedNucleus(
 
                   // Seed a nucleus if it was added to the list of nuclei this
                   // time step
-                  if (thisNucleus->seedingTimestep == this->currentIncrement)
+                  if (thisNucleus.seedingTimestep == this->currentIncrement)
                     {
                       // Find the weighted distance to the outer edge of the
                       // nucleus and use it to calculate the order parameter
@@ -169,15 +166,15 @@ customPDE<dim, degree>::seedNucleus(
                           q_point_loc_element(j) = q_point_loc(j)[i];
                         }
                       double r = this->weightedDistanceFromNucleusCenter(
-                        thisNucleus->center,
-                        userInputs.get_nucleus_semiaxes(thisNucleus->orderParameterIndex),
+                        thisNucleus.center,
+                        userInputs.get_nucleus_semiaxes(thisNucleus.orderParameterIndex),
                         q_point_loc_element,
-                        thisNucleus->orderParameterIndex);
+                        thisNucleus.orderParameterIndex);
 
                       double avg_semiaxis = 0.0;
                       for (unsigned int j = 0; j < dim; j++)
                         {
-                          avg_semiaxis += thisNucleus->semiaxes[j];
+                          avg_semiaxis += thisNucleus.semiaxes[j];
                         }
                       avg_semiaxis /= dim;
 

--- a/src/OrderParameterRemapper/OrderParameterRemapper.cc
+++ b/src/OrderParameterRemapper/OrderParameterRemapper.cc
@@ -17,17 +17,14 @@ OrderParameterRemapper<dim>::remap(
           double transfer_buffer =
             std::max(0.0, grain_representations.at(g).getDistanceToNeighbor() / 2.0);
 
-          typename dealii::DoFHandler<dim>::active_cell_iterator di =
-            dof_handler.begin_active();
-
           // For now I have two loops, one where I copy the values from the old
           // order parameter to the new one and a second where I zero out the
           // old order parameter. This separation prevents writing zero-out
           // values to the new order parameter. There probably is a more
           // efficient way of doing this.
-          while (di != dof_handler.end())
+          for (const auto &dof : dof_handler.active_cell_iterators())
             {
-              if (di->is_locally_owned())
+              if (dof->is_locally_owned())
                 {
                   unsigned int op_new = grain_representations.at(g).getOrderParameterId();
                   unsigned int op_old =
@@ -40,7 +37,7 @@ OrderParameterRemapper<dim>::remap(
                        v < dealii::GeometryInfo<dim>::vertices_per_cell;
                        v++)
                     {
-                      if (di->vertex(v).distance(
+                      if (dof->vertex(v).distance(
                             grain_representations.at(g).getCenter()) >
                           grain_representations.at(g).getRadius() + transfer_buffer)
                         {
@@ -56,7 +53,7 @@ OrderParameterRemapper<dim>::remap(
                       std::vector<dealii::types::global_dof_index> dof_indices(
                         dofs_per_cell,
                         0);
-                      di->get_dof_indices(dof_indices);
+                      dof->get_dof_indices(dof_indices);
                       for (unsigned int i = 0; i < dof_indices.size(); i++)
                         {
                           (*solution_fields.at(op_new))[dof_indices.at(i)] =
@@ -64,14 +61,11 @@ OrderParameterRemapper<dim>::remap(
                         }
                     }
                 }
-              ++di;
             }
 
-          di = dof_handler.begin_active();
-
-          while (di != dof_handler.end())
+          for (const auto &dof : dof_handler.active_cell_iterators())
             {
-              if (di->is_locally_owned())
+              if (dof->is_locally_owned())
                 {
                   unsigned int op_new = grain_representations.at(g).getOrderParameterId();
                   unsigned int op_old =
@@ -84,7 +78,7 @@ OrderParameterRemapper<dim>::remap(
                        v < dealii::GeometryInfo<dim>::vertices_per_cell;
                        v++)
                     {
-                      if (di->vertex(v).distance(
+                      if (dof->vertex(v).distance(
                             grain_representations.at(g).getCenter()) >
                           grain_representations.at(g).getRadius() + transfer_buffer)
                         {
@@ -99,7 +93,7 @@ OrderParameterRemapper<dim>::remap(
                       std::vector<dealii::types::global_dof_index> dof_indices(
                         dofs_per_cell,
                         0);
-                      di->get_dof_indices(dof_indices);
+                      dof->get_dof_indices(dof_indices);
 
                       for (unsigned int i = 0; i < dof_indices.size(); i++)
                         {
@@ -107,7 +101,6 @@ OrderParameterRemapper<dim>::remap(
                         }
                     }
                 }
-              ++di;
             }
         }
     }
@@ -141,9 +134,9 @@ OrderParameterRemapper<dim>::remap_from_index_field(
       // order parameter. This separation prevents writing zero-out values to
       // the new order parameter. There probably is a more efficient way of
       // doing this.
-      while (di != dof_handler.end())
+      for (const auto &dof : dof_handler.active_cell_iterators())
         {
-          if (di->is_locally_owned())
+          if (dof->is_locally_owned())
             {
               unsigned int op_new = grain_representations.at(g).getOrderParameterId();
               unsigned int op_old = grain_representations.at(g).getOldOrderParameterId();
@@ -153,7 +146,7 @@ OrderParameterRemapper<dim>::remap_from_index_field(
               for (unsigned int v = 0; v < dealii::GeometryInfo<dim>::vertices_per_cell;
                    v++)
                 {
-                  if (di->vertex(v).distance(grain_representations.at(g).getCenter()) >
+                  if (dof->vertex(v).distance(grain_representations.at(g).getCenter()) >
                       grain_representations.at(g).getRadius() + transfer_buffer)
                     {
                       in_grain = false;
@@ -167,7 +160,7 @@ OrderParameterRemapper<dim>::remap_from_index_field(
                 {
                   std::vector<dealii::types::global_dof_index> dof_indices(dofs_per_cell,
                                                                            0);
-                  di->get_dof_indices(dof_indices);
+                  dof->get_dof_indices(dof_indices);
                   for (unsigned int i = 0; i < dof_indices.size(); i++)
                     {
                       if (std::abs((*grain_index_field)[dof_indices.at(i)] -
@@ -179,7 +172,6 @@ OrderParameterRemapper<dim>::remap_from_index_field(
                     }
                 }
             }
-          ++di;
         }
     }
 }

--- a/src/matrixfree/boundaryConditions.cc
+++ b/src/matrixfree/boundaryConditions.cc
@@ -39,10 +39,6 @@ MatrixFreePDE<dim, degree>::applyNeumannBCs()
           if (userInputs.BC_list[starting_BC_list_index].var_BC_type[direction] ==
               NEUMANN)
             {
-              typename DoFHandler<dim>::active_cell_iterator cell = dofHandlersSet[0]
-                                                                      ->begin_active(),
-                                                             endc =
-                                                               dofHandlersSet[0]->end();
               FESystem<dim>         *fe = FESet[currentFieldIndex];
               QGaussLobatto<dim - 1> face_quadrature_formula(degree + 1);
               FEFaceValues<dim>      fe_face_values(*fe,
@@ -54,7 +50,7 @@ MatrixFreePDE<dim, degree>::applyNeumannBCs()
               std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
               // Loop over each face on a boundary
-              for (; cell != endc; ++cell)
+              for (const auto &cell : dofHandlersSet[0]->active_cell_iterators())
                 {
                   for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
                     {
@@ -357,10 +353,7 @@ MatrixFreePDE<dim, degree>::setRigidBodyModeConstraints(
       unsigned int vertices_per_cell = GeometryInfo<dim>::vertices_per_cell;
 
       // Loop over each locally owned cell
-      typename DoFHandler<dim>::active_cell_iterator cell = dof_handler->begin_active(),
-                                                     endc = dof_handler->end();
-
-      for (; cell != endc; ++cell)
+      for (const auto &cell : dof_handler->active_cell_iterators())
         {
           if (cell->is_locally_owned())
             {

--- a/src/matrixfree/computeIntegral.cc
+++ b/src/matrixfree/computeIntegral.cc
@@ -19,13 +19,9 @@ MatrixFreePDE<dim, degree>::computeIntegral(double                   &integrated
   // constraintsOtherSet[index]->distribute(*variableSet[index]);
   // variableSet[index]->update_ghost_values();
 
-  typename DoFHandler<dim>::active_cell_iterator cell = this->dofHandlersSet[0]
-                                                          ->begin_active(),
-                                                 endc = this->dofHandlersSet[0]->end();
-
   double value = 0.0;
 
-  for (; cell != endc; ++cell)
+  for (const auto &cell : dofHandlersSet[0]->active_cell_iterators())
     {
       if (cell->is_locally_owned())
         {

--- a/src/matrixfree/initForTests.cc
+++ b/src/matrixfree/initForTests.cc
@@ -38,16 +38,15 @@ MatrixFreePDE<dim, degree>::initForTests(std::vector<Field<dim>> fields)
     }
 
   // setup system
-  for (typename std::vector<Field<dim>>::iterator it = fields.begin(); it != fields.end();
-       ++it)
+  for (auto &field : fields)
     {
       // create FESystem
       FESystem<dim> *fe;
-      if (it->type == SCALAR)
+      if (field.type == SCALAR)
         {
           fe = new FESystem<dim>(FE_Q<dim>(QGaussLobatto<1>(degree + 1)), 1);
         }
-      else if (it->type == VECTOR)
+      else if (field.type == VECTOR)
         {
           fe = new FESystem<dim>(FE_Q<dim>(QGaussLobatto<1>(degree + 1)), dim);
         }

--- a/src/matrixfree/markBoundaries.cc
+++ b/src/matrixfree/markBoundaries.cc
@@ -10,9 +10,7 @@ void
 MatrixFreePDE<dim, degree>::markBoundaries(
   parallel::distributed::Triangulation<dim> &tria) const
 {
-  typename Triangulation<dim>::cell_iterator cell = tria.begin(), endc = tria.end();
-
-  for (; cell != endc; ++cell)
+  for (const auto &cell : tria.active_cell_iterators())
     {
       // Mark all of the faces
       for (unsigned int face_number = 0; face_number < GeometryInfo<dim>::faces_per_cell;

--- a/src/matrixfree/nucleation.cc
+++ b/src/matrixfree/nucleation.cc
@@ -129,9 +129,6 @@ MatrixFreePDE<dim, degree>::getLocalNucleiList(std::vector<nucleus<dim>> &newnuc
 
   std::vector<dealii::Point<dim>> q_point_list_overlap(num_quad_points);
 
-  typename DoFHandler<dim>::active_cell_iterator di =
-    dofHandlersSet_nonconst[0]->begin_active();
-
   // What used to be in nuc_attempt
   double rand_val;
   // Better random no. generator
@@ -140,13 +137,13 @@ MatrixFreePDE<dim, degree>::getLocalNucleiList(std::vector<nucleus<dim>> &newnuc
   std::uniform_real_distribution<> distr(0.0, 1.0);
 
   // Element cycle
-  while (di != this->dofHandlersSet_nonconst[0]->end())
+  for (const auto &dof : dofHandlersSet_nonconst[0]->active_cell_iterators())
     {
-      if (di->is_locally_owned())
+      if (dof->is_locally_owned())
         {
           // Obtaining average element concentration by averaging over element's
           // quadrature points
-          fe_values.reinit(di);
+          fe_values.reinit(dof);
           for (unsigned int var = 0; var < userInputs.nucleation_need_value.size(); var++)
             {
               fe_values.get_function_values(
@@ -320,8 +317,6 @@ MatrixFreePDE<dim, degree>::getLocalNucleiList(std::vector<nucleus<dim>> &newnuc
                 }
             }
         }
-      // Increment the cell iterators
-      ++di;
     }
 }
 
@@ -346,20 +341,17 @@ MatrixFreePDE<dim, degree>::safetyCheckNewNuclei(std::vector<nucleus<dim>>  newn
   std::vector<dealii::Point<dim>> q_point_list(num_quad_points);
 
   // Nucleus cycle
-  for (typename std::vector<nucleus<dim>>::iterator thisNucleus = newnuclei.begin();
-       thisNucleus != newnuclei.end();
-       ++thisNucleus)
+  for (const auto &thisNucleus : newnuclei)
     {
       bool isClose = false;
 
       // Element cycle
-      typename DoFHandler<dim>::active_cell_iterator di =
-        dofHandlersSet_nonconst[0]->begin_active();
-      while (di != dofHandlersSet_nonconst[0]->end())
+
+      for (const auto &dof : dofHandlersSet_nonconst[0]->active_cell_iterators())
         {
-          if (di->is_locally_owned())
+          if (dof->is_locally_owned())
             {
-              fe_values.reinit(di);
+              fe_values.reinit(dof);
               for (unsigned int var = 0;
                    var < userInputs.nucleating_variable_indices.size();
                    var++)
@@ -376,11 +368,11 @@ MatrixFreePDE<dim, degree>::safetyCheckNewNuclei(std::vector<nucleus<dim>>  newn
                   // Calculate the ellipsoidal distance to the center of the
                   // nucleus
                   double weighted_dist = weightedDistanceFromNucleusCenter(
-                    thisNucleus->center,
+                    thisNucleus.center,
                     userInputs.get_nucleus_freeze_semiaxes(
-                      thisNucleus->orderParameterIndex),
+                      thisNucleus.orderParameterIndex),
                     q_point_list[q_point],
-                    thisNucleus->orderParameterIndex);
+                    thisNucleus.orderParameterIndex);
 
                   if (weighted_dist < 1.0)
                     {
@@ -397,7 +389,7 @@ MatrixFreePDE<dim, degree>::safetyCheckNewNuclei(std::vector<nucleus<dim>>  newn
                           std::cout << "Attempted nucleation failed due to "
                                        "overlap w/ existing particle!!!!!!"
                                     << std::endl;
-                          conflict_ids.push_back(thisNucleus->index);
+                          conflict_ids.push_back(thisNucleus.index);
                           break;
                         }
                     }
@@ -405,8 +397,6 @@ MatrixFreePDE<dim, degree>::safetyCheckNewNuclei(std::vector<nucleus<dim>>  newn
               if (isClose)
                 break;
             }
-          // Increment the cell iterators
-          ++di;
         }
     }
 }
@@ -427,7 +417,6 @@ MatrixFreePDE<dim, degree>::refineMeshNearNuclei(std::vector<nucleus<dim>> newnu
   std::vector<dealii::Point<dim>> q_point_list(num_quad_points);
 
   typename Triangulation<dim>::active_cell_iterator ti;
-  typename DoFHandler<dim>::active_cell_iterator    di;
 
   unsigned int numDoF_preremesh = totalDOFs;
 
@@ -436,14 +425,13 @@ MatrixFreePDE<dim, degree>::refineMeshNearNuclei(std::vector<nucleus<dim>> newnu
        remesh_index++)
     {
       ti = triangulation.begin_active();
-      di = dofHandlersSet_nonconst[0]->begin_active();
-      while (di != dofHandlersSet_nonconst[0]->end())
+      for (const auto &dof : dofHandlersSet_nonconst[0]->active_cell_iterators())
         {
-          if (di->is_locally_owned())
+          if (dof->is_locally_owned())
             {
               bool mark_refine = false;
 
-              fe_values.reinit(di);
+              fe_values.reinit(dof);
               q_point_list = fe_values.get_quadrature_points();
 
               // Calculate the distance from the corner of the cell to the
@@ -459,22 +447,19 @@ MatrixFreePDE<dim, degree>::refineMeshNearNuclei(std::vector<nucleus<dim>> newnu
 
               for (unsigned int q_point = 0; q_point < num_quad_points; ++q_point)
                 {
-                  for (typename std::vector<nucleus<dim>>::iterator thisNucleus =
-                         newnuclei.begin();
-                       thisNucleus != newnuclei.end();
-                       ++thisNucleus)
+                  for (const auto &thisNucleus : newnuclei)
                     {
                       // Calculate the ellipsoidal distance to the center of the
                       // nucleus
                       double weighted_dist = weightedDistanceFromNucleusCenter(
-                        thisNucleus->center,
+                        thisNucleus.center,
                         userInputs.get_nucleus_freeze_semiaxes(
-                          thisNucleus->orderParameterIndex),
+                          thisNucleus.orderParameterIndex),
                         q_point_list[q_point],
-                        thisNucleus->orderParameterIndex);
+                        thisNucleus.orderParameterIndex);
 
                       if (weighted_dist < 1.0 ||
-                          thisNucleus->center.distance(q_point_list[q_point]) < diag_dist)
+                          thisNucleus.center.distance(q_point_list[q_point]) < diag_dist)
                         {
                           if ((unsigned int) ti->level() <
                               userInputs.max_refinement_level)
@@ -490,9 +475,8 @@ MatrixFreePDE<dim, degree>::refineMeshNearNuclei(std::vector<nucleus<dim>> newnu
                     break;
                 }
               if (mark_refine)
-                di->set_refine_flag();
+                dof->set_refine_flag();
             }
-          ++di;
           ++ti;
         }
       // The bulk of all of modifySolutionFields is spent in the following two function

--- a/src/matrixfree/reinit.cc
+++ b/src/matrixfree/reinit.cc
@@ -12,27 +12,26 @@ MatrixFreePDE<dim, degree>::reinit()
   // setup system
   pcout << "Reinitializing matrix free object\n";
   totalDOFs = 0;
-  for (typename std::vector<Field<dim>>::iterator it = fields.begin(); it != fields.end();
-       ++it)
+  for (const auto &field : fields)
     {
-      currentFieldIndex = it->index;
+      currentFieldIndex = field.index;
 
       char buffer[100];
 
       // create FESystem
       FESystem<dim> *fe;
-      fe = FESet.at(it->index);
+      fe = FESet.at(field.index);
 
       // distribute DOFs
       DoFHandler<dim> *dof_handler;
-      dof_handler = dofHandlersSet_nonconst.at(it->index);
+      dof_handler = dofHandlersSet_nonconst.at(field.index);
 
       dof_handler->distribute_dofs(*fe);
       totalDOFs += dof_handler->n_dofs();
 
       // extract locally_relevant_dofs
       IndexSet *locally_relevant_dofs;
-      locally_relevant_dofs = locally_relevant_dofsSet_nonconst.at(it->index);
+      locally_relevant_dofs = locally_relevant_dofsSet_nonconst.at(field.index);
 
       locally_relevant_dofs->clear();
       DoFTools::extract_locally_relevant_dofs(*dof_handler, *locally_relevant_dofs);
@@ -40,8 +39,8 @@ MatrixFreePDE<dim, degree>::reinit()
       // create constraints
       AffineConstraints<double> *constraintsDirichlet, *constraintsOther;
 
-      constraintsDirichlet = constraintsDirichletSet_nonconst.at(it->index);
-      constraintsOther     = constraintsOtherSet_nonconst.at(it->index);
+      constraintsDirichlet = constraintsDirichletSet_nonconst.at(field.index);
+      constraintsOther     = constraintsOtherSet_nonconst.at(field.index);
 
       constraintsDirichlet->clear();
       constraintsDirichlet->reinit(*locally_relevant_dofs);
@@ -67,14 +66,14 @@ MatrixFreePDE<dim, degree>::reinit()
       constraintsOther->close();
 
       // Store Dirichlet BC DOF's
-      valuesDirichletSet[it->index]->clear();
+      valuesDirichletSet[field.index]->clear();
       for (types::global_dof_index i = 0; i < dof_handler->n_dofs(); i++)
         {
           if (locally_relevant_dofs->is_element(i))
             {
               if (constraintsDirichlet->is_constrained(i))
                 {
-                  (*valuesDirichletSet[it->index])[i] =
+                  (*valuesDirichletSet[field.index])[i] =
                     constraintsDirichlet->get_inhomogeneity(i);
                 }
             }
@@ -83,7 +82,7 @@ MatrixFreePDE<dim, degree>::reinit()
       snprintf(buffer,
                sizeof(buffer),
                "field '%2s' DOF : %u (Constraint DOF : %u)\n",
-               it->name.c_str(),
+               field.name.c_str(),
                dof_handler->n_dofs(),
                constraintsDirichlet->n_constraints());
       pcout << buffer;

--- a/src/matrixfree/setNonlinearEqInitialGuess.cc
+++ b/src/matrixfree/setNonlinearEqInitialGuess.cc
@@ -24,14 +24,11 @@ MatrixFreePDE<dim, degree>::setNonlinearEqInitialGuess()
 
           computeLaplaceRHS(fieldIndex);
 
-          for (std::map<types::global_dof_index, double>::const_iterator it =
-                 valuesDirichletSet[fieldIndex]->begin();
-               it != valuesDirichletSet[fieldIndex]->end();
-               ++it)
+          for (const auto &it : *valuesDirichletSet[fieldIndex])
             {
-              if (residualSet[fieldIndex]->in_local_range(it->first))
+              if (residualSet[fieldIndex]->in_local_range(it.first))
                 {
-                  (*residualSet[fieldIndex])(it->first) = 0.0;
+                  (*residualSet[fieldIndex])(it.first) = 0.0;
                 }
             }
 

--- a/src/matrixfree/solveIncrement.cc
+++ b/src/matrixfree/solveIncrement.cc
@@ -189,15 +189,11 @@ MatrixFreePDE<dim, degree>::solveIncrement(bool skip_time_dependent)
 
                               computeNonexplicitRHS();
 
-                              for (std::map<types::global_dof_index,
-                                            double>::const_iterator it =
-                                     valuesDirichletSet[fieldIndex]->begin();
-                                   it != valuesDirichletSet[fieldIndex]->end();
-                                   ++it)
+                              for (const auto &it : *valuesDirichletSet[fieldIndex])
                                 {
-                                  if (residualSet[fieldIndex]->in_local_range(it->first))
+                                  if (residualSet[fieldIndex]->in_local_range(it.first))
                                     {
-                                      (*residualSet[fieldIndex])(it->first) = 0.0;
+                                      (*residualSet[fieldIndex])(it.first) = 0.0;
                                     }
                                 }
 

--- a/src/matrixfree/utilities.cc
+++ b/src/matrixfree/utilities.cc
@@ -7,11 +7,10 @@ template <int dim, int degree>
 unsigned int
 MatrixFreePDE<dim, degree>::getFieldIndex(std::string _name)
 {
-  for (typename std::vector<Field<dim>>::iterator it = fields.begin(); it != fields.end();
-       ++it)
+  for (const auto &field : fields)
     {
-      if (it->name.compare(_name) == 0)
-        return it->index;
+      if (field.name.compare(_name) == 0)
+        return field.index;
     }
   pcout << "\nutilities.h: field '" << _name.c_str() << "' not initialized\n";
   exit(-1);

--- a/src/parallelNucleationList/parallelNucleationList.cc
+++ b/src/parallelNucleationList/parallelNucleationList.cc
@@ -97,27 +97,24 @@ parallelNucleationList<dim>::sendUpdate(int procno) const
       std::vector<unsigned int> s_orderParameterIndex;
 
       // Loop to store info of all nuclei into vectors
-      for (typename std::vector<nucleus<dim>>::const_iterator thisNuclei =
-             newnuclei.begin();
-           thisNuclei != newnuclei.end();
-           ++thisNuclei)
+      for (const auto &thisNuclei : newnuclei)
         {
-          s_index.push_back(thisNuclei->index);
-          dealii::Point<dim> s_center = thisNuclei->center;
+          s_index.push_back(thisNuclei.index);
+          dealii::Point<dim> s_center = thisNuclei.center;
           s_center_x.push_back(s_center[0]);
           s_center_y.push_back(s_center[1]);
           if (dim == 3)
             s_center_z.push_back(s_center[2]);
 
-          s_semiaxis_a.push_back(thisNuclei->semiaxes[0]);
-          s_semiaxis_b.push_back(thisNuclei->semiaxes[1]);
+          s_semiaxis_a.push_back(thisNuclei.semiaxes[0]);
+          s_semiaxis_b.push_back(thisNuclei.semiaxes[1]);
           if (dim == 3)
-            s_semiaxis_c.push_back(thisNuclei->semiaxes[2]);
+            s_semiaxis_c.push_back(thisNuclei.semiaxes[2]);
 
-          s_seededTime.push_back(thisNuclei->seededTime);
-          s_seedingTime.push_back(thisNuclei->seedingTime);
-          s_seedingTimestep.push_back(thisNuclei->seedingTimestep);
-          s_orderParameterIndex.push_back(thisNuclei->orderParameterIndex);
+          s_seededTime.push_back(thisNuclei.seededTime);
+          s_seedingTime.push_back(thisNuclei.seedingTime);
+          s_seedingTimestep.push_back(thisNuclei.seedingTimestep);
+          s_orderParameterIndex.push_back(thisNuclei.orderParameterIndex);
         }
       // Send vectors to next processor
       MPI_Send(&s_index[0], currnonucs, MPI_UNSIGNED, procno, 1, MPI_COMM_WORLD);
@@ -341,13 +338,10 @@ parallelNucleationList<dim>::broadcastUpdate(int broadcastProc, int thisProc)
 
       if (thisProc == broadcastProc)
         {
-          for (typename std::vector<nucleus<dim>>::iterator thisNuclei =
-                 newnuclei.begin();
-               thisNuclei != newnuclei.end();
-               ++thisNuclei)
+          for (const auto &thisNuclei : newnuclei)
             {
-              r_index.push_back(thisNuclei->index);
-              dealii::Point<dim> s_center = thisNuclei->center;
+              r_index.push_back(thisNuclei.index);
+              dealii::Point<dim> s_center = thisNuclei.center;
               r_center_x.push_back(s_center[0]);
               r_center_y.push_back(s_center[1]);
               if (dim == 3)
@@ -355,17 +349,17 @@ parallelNucleationList<dim>::broadcastUpdate(int broadcastProc, int thisProc)
                   r_center_z.push_back(s_center[2]);
                 }
 
-              r_semiaxis_a.push_back(thisNuclei->semiaxes[0]);
-              r_semiaxis_b.push_back(thisNuclei->semiaxes[1]);
+              r_semiaxis_a.push_back(thisNuclei.semiaxes[0]);
+              r_semiaxis_b.push_back(thisNuclei.semiaxes[1]);
               if (dim == 3)
                 {
-                  r_semiaxis_c.push_back(thisNuclei->semiaxes[2]);
+                  r_semiaxis_c.push_back(thisNuclei.semiaxes[2]);
                 }
 
-              r_seededTime.push_back(thisNuclei->seededTime);
-              r_seedingTime.push_back(thisNuclei->seedingTime);
-              r_seedingTimestep.push_back(thisNuclei->seedingTimestep);
-              r_orderParameterIndex.push_back(thisNuclei->orderParameterIndex);
+              r_seededTime.push_back(thisNuclei.seededTime);
+              r_seedingTime.push_back(thisNuclei.seedingTime);
+              r_seedingTimestep.push_back(thisNuclei.seedingTimestep);
+              r_orderParameterIndex.push_back(thisNuclei.orderParameterIndex);
             }
         }
 


### PR DESCRIPTION
Range based loops from C++11 are a bit more readable and a good way to simplify the loop structures. 

I converted all the loops (except for those `FloodFiller.cc`).