### PR TITLE
Fix multiple linear/nonlinear solves

### DIFF
--- a/include/model_variables.h
+++ b/include/model_variables.h
@@ -34,7 +34,6 @@ public:
 struct variable_info
 {
   bool                                     is_scalar;
-  unsigned int                             variable_index;
   unsigned int                             global_var_index;
   dealii::EvaluationFlags::EvaluationFlags evaluation_flags;
   dealii::EvaluationFlags::EvaluationFlags residual_flags;

--- a/include/variableContainer.h
+++ b/include/variableContainer.h
@@ -126,8 +126,10 @@ private:
   boost::unordered_map<unsigned int, std::unique_ptr<scalar_FEEval>> scalar_vars_map;
   boost::unordered_map<unsigned int, std::unique_ptr<vector_FEEval>> vector_vars_map;
 
-  std::vector<scalar_FEEval> scalar_change_in_vars;
-  std::vector<vector_FEEval> vector_change_in_vars;
+  boost::unordered_map<unsigned int, std::unique_ptr<scalar_FEEval>>
+    scalar_change_in_vars_map;
+  boost::unordered_map<unsigned int, std::unique_ptr<vector_FEEval>>
+    vector_change_in_vars_map;
 
   // Object containing some information about each variable (indices, whether
   // the val/grad/hess is needed, etc)

--- a/include/variableContainer.h
+++ b/include/variableContainer.h
@@ -3,10 +3,13 @@
 #ifndef VARIBLECONTAINER_H
 #define VARIBLECONTAINER_H
 
+#include <deal.II/base/exceptions.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/matrix_free/evaluation_flags.h>
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>
+
+#include <boost/unordered_map.hpp>
 
 #include "userInputParameters.h"
 
@@ -90,11 +93,6 @@ public:
   reinit_and_eval_change_in_solution(const vectorType &src,
                                      unsigned int      cell,
                                      unsigned int      var_being_solved);
-  void
-  reinit_and_eval_LHS(const vectorType               &src,
-                      const std::vector<vectorType *> solutionSet,
-                      unsigned int                    cell,
-                      unsigned int                    var_being_solved);
 
   // Only initialize the FEEvaluation object for each variable (used for
   // post-processing)
@@ -117,23 +115,24 @@ public:
   get_q_point_location();
 
 private:
-  // The number of variables
-  unsigned int num_var;
-
   // Vectors of the actual FEEvaluation objects for each active variable, split
   // into scalar variables and vector variables for type reasons
-  std::vector<dealii::FEEvaluation<dim, degree, degree + 1, 1, double>>   scalar_vars;
-  std::vector<dealii::FEEvaluation<dim, degree, degree + 1, dim, double>> vector_vars;
+  using scalar_FEEval = dealii::FEEvaluation<dim, degree, degree + 1, 1, double>;
+  using vector_FEEval = dealii::FEEvaluation<dim, degree, degree + 1, dim, double>;
 
-  std::vector<dealii::FEEvaluation<dim, degree, degree + 1, 1, double>>
-    scalar_change_in_vars;
-  std::vector<dealii::FEEvaluation<dim, degree, degree + 1, dim, double>>
-    vector_change_in_vars;
+  boost::unordered_map<unsigned int, std::unique_ptr<scalar_FEEval>> scalar_vars_map;
+  boost::unordered_map<unsigned int, std::unique_ptr<vector_FEEval>> vector_vars_map;
+
+  std::vector<scalar_FEEval> scalar_change_in_vars;
+  std::vector<vector_FEEval> vector_change_in_vars;
 
   // Object containing some information about each variable (indices, whether
   // the val/grad/hess is needed, etc)
   std::vector<variable_info> varInfoList;
   std::vector<variable_info> varChangeInfoList;
+
+  // The number of variables
+  unsigned int num_var;
 };
 
 #endif

--- a/include/variableContainer.h
+++ b/include/variableContainer.h
@@ -22,15 +22,16 @@ public:
 
   // Standard contructor, used for most situations
   variableContainer(const dealii::MatrixFree<dim, double> &data,
-                    std::vector<variable_info>             _varInfoList,
-                    std::vector<variable_info>             _varChangeInfoList);
+                    const std::vector<variable_info>      &_varInfoList,
+                    const std::vector<variable_info>      &_varChangeInfoList);
+
   variableContainer(const dealii::MatrixFree<dim, double> &data,
-                    std::vector<variable_info>             _varInfoList);
+                    const std::vector<variable_info>      &_varInfoList);
   // Nonstandard constructor, used when only one index of "data" should be used,
   // use with care!
   variableContainer(const dealii::MatrixFree<dim, double> &data,
-                    std::vector<variable_info>             _varInfoList,
-                    unsigned int                           fixed_index);
+                    const std::vector<variable_info>      &_varInfoList,
+                    const unsigned int                    &fixed_index);
 
   // Methods to get the value/grad/hess in the residual method (this is how the
   // user gets these values in equations.h)
@@ -109,10 +110,12 @@ public:
   // The quadrature point index, a method to get the number of quadrature points
   // per cell, and a method to get the xyz coordinates for the quadrature point
   unsigned int q_point;
+
   unsigned int
-  get_num_q_points();
+  get_num_q_points() const;
+
   dealii::Point<dim, T>
-  get_q_point_location();
+  get_q_point_location() const;
 
 private:
   // Vectors of the actual FEEvaluation objects for each active variable, split

--- a/src/matrixfree/computeLHS.cc
+++ b/src/matrixfree/computeLHS.cc
@@ -57,7 +57,6 @@ MatrixFreePDE<dim, degree>::getLHS(
   for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
     {
       // Initialize, read DOFs, and set evaulation flags for each variable
-      // variable_list.reinit_and_eval_LHS(src,solutionSet,cell,currentFieldIndex);
       variable_list.reinit_and_eval(solutionSet, cell);
       variable_list.reinit_and_eval_change_in_solution(src, cell, currentFieldIndex);
 

--- a/src/userInputParameters/loadVariableAttributes.cc
+++ b/src/userInputParameters/loadVariableAttributes.cc
@@ -50,8 +50,6 @@ userInputParameters<dim>::loadVariableAttributes(
         }
     }
   varInfoListExplicitRHS.reserve(num_var_explicit_RHS);
-  unsigned int scalar_var_index = 0;
-  unsigned int vector_var_index = 0;
   for (unsigned int i = 0; i < number_of_variables; i++)
     {
       variable_info varInfo;
@@ -64,28 +62,9 @@ userInputParameters<dim>::loadVariableAttributes(
 
       varInfo.global_var_index = i;
 
-      !(varInfo.evaluation_flags & dealii::EvaluationFlags::nothing)
-        ? varInfo.var_needed = true
-        : varInfo.var_needed = false;
+      varInfo.var_needed = !(varInfo.evaluation_flags & dealii::EvaluationFlags::nothing);
 
-      if (var_type[i] == SCALAR)
-        {
-          varInfo.is_scalar = true;
-          if (varInfo.var_needed)
-            {
-              varInfo.variable_index = scalar_var_index;
-              scalar_var_index++;
-            }
-        }
-      else
-        {
-          varInfo.is_scalar = false;
-          if (varInfo.var_needed)
-            {
-              varInfo.variable_index = vector_var_index;
-              vector_var_index++;
-            }
-        }
+      varInfo.is_scalar = var_type[i] == SCALAR;
 
       varInfoListExplicitRHS.push_back(varInfo);
     }
@@ -101,8 +80,6 @@ userInputParameters<dim>::loadVariableAttributes(
         }
     }
   varInfoListNonexplicitRHS.reserve(num_var_nonexplicit_RHS);
-  scalar_var_index = 0;
-  vector_var_index = 0;
   for (unsigned int i = 0; i < number_of_variables; i++)
     {
       variable_info varInfo;
@@ -115,28 +92,9 @@ userInputParameters<dim>::loadVariableAttributes(
 
       varInfo.global_var_index = i;
 
-      !(varInfo.evaluation_flags & dealii::EvaluationFlags::nothing)
-        ? varInfo.var_needed = true
-        : varInfo.var_needed = false;
+      varInfo.var_needed = !(varInfo.evaluation_flags & dealii::EvaluationFlags::nothing);
 
-      if (var_type[i] == SCALAR)
-        {
-          varInfo.is_scalar = true;
-          if (varInfo.var_needed)
-            {
-              varInfo.variable_index = scalar_var_index;
-              scalar_var_index++;
-            }
-        }
-      else
-        {
-          varInfo.is_scalar = false;
-          if (varInfo.var_needed)
-            {
-              varInfo.variable_index = vector_var_index;
-              vector_var_index++;
-            }
-        }
+      varInfo.is_scalar = var_type[i] == SCALAR;
 
       varInfoListNonexplicitRHS.push_back(varInfo);
     }
@@ -153,8 +111,6 @@ userInputParameters<dim>::loadVariableAttributes(
     }
 
   varInfoListLHS.reserve(num_var_LHS);
-  scalar_var_index = 0;
-  vector_var_index = 0;
   for (unsigned int i = 0; i < number_of_variables; i++)
     {
       variable_info varInfo;
@@ -167,35 +123,14 @@ userInputParameters<dim>::loadVariableAttributes(
 
       varInfo.global_var_index = i;
 
-      !(varInfo.evaluation_flags & dealii::EvaluationFlags::nothing)
-        ? varInfo.var_needed = true
-        : varInfo.var_needed = false;
+      varInfo.var_needed = !(varInfo.evaluation_flags & dealii::EvaluationFlags::nothing);
 
-      if (var_type[i] == SCALAR)
-        {
-          varInfo.is_scalar = true;
-          if (varInfo.var_needed)
-            {
-              varInfo.variable_index = scalar_var_index;
-              scalar_var_index++;
-            }
-        }
-      else
-        {
-          varInfo.is_scalar = false;
-          if (varInfo.var_needed)
-            {
-              varInfo.variable_index = vector_var_index;
-              vector_var_index++;
-            }
-        }
+      varInfo.is_scalar = var_type[i] == SCALAR;
 
       varInfoListLHS.push_back(varInfo);
     }
 
   varChangeInfoListLHS.reserve(num_var_LHS);
-  scalar_var_index = 0;
-  vector_var_index = 0;
   for (unsigned int i = 0; i < number_of_variables; i++)
     {
       variable_info varInfo;
@@ -209,28 +144,9 @@ userInputParameters<dim>::loadVariableAttributes(
 
       varInfo.global_var_index = i;
 
-      !(varInfo.evaluation_flags & dealii::EvaluationFlags::nothing)
-        ? varInfo.var_needed = true
-        : varInfo.var_needed = false;
+      varInfo.var_needed = !(varInfo.evaluation_flags & dealii::EvaluationFlags::nothing);
 
-      if (var_type[i] == SCALAR)
-        {
-          varInfo.is_scalar = true;
-          if (varInfo.var_needed)
-            {
-              varInfo.variable_index = scalar_var_index;
-              scalar_var_index++;
-            }
-        }
-      else
-        {
-          varInfo.is_scalar = false;
-          if (varInfo.var_needed)
-            {
-              varInfo.variable_index = vector_var_index;
-              vector_var_index++;
-            }
-        }
+      varInfo.is_scalar = var_type[i] == SCALAR;
 
       varChangeInfoListLHS.push_back(varInfo);
     }
@@ -238,8 +154,6 @@ userInputParameters<dim>::loadVariableAttributes(
   // Load variable information for postprocessing
   // First, the info list for the base field variables
   pp_baseVarInfoList.reserve(number_of_variables);
-  scalar_var_index = 0;
-  vector_var_index = 0;
   for (unsigned int i = 0; i < number_of_variables; i++)
     {
       variable_info varInfo;
@@ -249,28 +163,9 @@ userInputParameters<dim>::loadVariableAttributes(
 
       varInfo.global_var_index = i;
 
-      !(varInfo.evaluation_flags & dealii::EvaluationFlags::nothing)
-        ? varInfo.var_needed = true
-        : varInfo.var_needed = false;
+      varInfo.var_needed = !(varInfo.evaluation_flags & dealii::EvaluationFlags::nothing);
 
-      if (var_type[i] == SCALAR)
-        {
-          varInfo.is_scalar = true;
-          if (varInfo.var_needed)
-            {
-              varInfo.variable_index = scalar_var_index;
-              scalar_var_index++;
-            }
-        }
-      else
-        {
-          varInfo.is_scalar = false;
-          if (varInfo.var_needed)
-            {
-              varInfo.variable_index = vector_var_index;
-              vector_var_index++;
-            }
-        }
+      varInfo.is_scalar = var_type[i] == SCALAR;
 
       pp_baseVarInfoList.push_back(varInfo);
     }
@@ -292,8 +187,6 @@ userInputParameters<dim>::loadVariableAttributes(
 
   // The info list for the postprocessing field variables
   pp_varInfoList.reserve(pp_number_of_variables);
-  scalar_var_index = 0;
-  vector_var_index = 0;
   for (unsigned int i = 0; i < pp_number_of_variables; i++)
     {
       variable_info varInfo;
@@ -303,18 +196,9 @@ userInputParameters<dim>::loadVariableAttributes(
         variable_attributes.equation_dependency_parser.eval_flags_residual_postprocess[i];
 
       varInfo.global_var_index = i;
-      if (pp_var_type[i] == SCALAR)
-        {
-          varInfo.is_scalar      = true;
-          varInfo.variable_index = scalar_var_index;
-          scalar_var_index++;
-        }
-      else
-        {
-          varInfo.is_scalar      = false;
-          varInfo.variable_index = vector_var_index;
-          vector_var_index++;
-        }
+
+      varInfo.is_scalar = pp_var_type[i] == SCALAR;
+
       pp_varInfoList.push_back(varInfo);
     }
 }

--- a/src/variableContainer/variableContainer.cc
+++ b/src/variableContainer/variableContainer.cc
@@ -16,7 +16,7 @@ variableContainer<dim, degree, T>::variableContainer(
 
       if (var_info.var_needed)
         {
-          const unsigned int var_index = var_info.variable_index;
+          const unsigned int var_index = var_info.global_var_index;
 
           if (var_info.is_scalar)
             {
@@ -64,7 +64,7 @@ variableContainer<dim, degree, T>::variableContainer(
           continue;
         }
 
-      const unsigned int var_index = var_info.variable_index;
+      const unsigned int var_index = var_info.global_var_index;
 
       if (var_info.is_scalar)
         {
@@ -96,7 +96,7 @@ variableContainer<dim, degree, T>::variableContainer(
           continue;
         }
 
-      const unsigned int var_index = var_info.variable_index;
+      const unsigned int var_index = var_info.global_var_index;
 
       if (var_info.is_scalar)
         {
@@ -183,7 +183,7 @@ variableContainer<dim, degree, T>::reinit_and_eval(const std::vector<vectorType 
           continue;
         }
 
-      const unsigned int var_index = var_info.variable_index;
+      const unsigned int var_index = var_info.global_var_index;
 
       if (var_info.is_scalar)
         {
@@ -242,7 +242,7 @@ variableContainer<dim, degree, T>::reinit(unsigned int cell)
           continue;
         }
 
-      const unsigned int var_index = var_info.variable_index;
+      const unsigned int var_index = var_info.global_var_index;
 
       if (var_info.is_scalar)
         {
@@ -269,7 +269,7 @@ variableContainer<dim, degree, T>::integrate_and_distribute(
           continue;
         }
 
-      const unsigned int var_index = var_info.variable_index;
+      const unsigned int var_index = var_info.global_var_index;
 
       if (var_info.is_scalar)
         {
@@ -317,8 +317,7 @@ variableContainer<dim, degree, T>::get_scalar_value(
   if (varInfoList[global_variable_index].evaluation_flags &
       dealii::EvaluationFlags::values)
     {
-      return scalar_vars_map.at(varInfoList[global_variable_index].variable_index)
-        ->get_value(q_point);
+      return scalar_vars_map.at(global_variable_index)->get_value(q_point);
     }
   else
     {
@@ -338,8 +337,7 @@ variableContainer<dim, degree, T>::get_scalar_gradient(
   if (varInfoList[global_variable_index].evaluation_flags &
       dealii::EvaluationFlags::gradients)
     {
-      return scalar_vars_map.at(varInfoList[global_variable_index].variable_index)
-        ->get_gradient(q_point);
+      return scalar_vars_map.at(global_variable_index)->get_gradient(q_point);
     }
   else
     {
@@ -359,8 +357,7 @@ variableContainer<dim, degree, T>::get_scalar_hessian(
   if (varInfoList[global_variable_index].evaluation_flags &
       dealii::EvaluationFlags::hessians)
     {
-      return scalar_vars_map.at(varInfoList[global_variable_index].variable_index)
-        ->get_hessian(q_point);
+      return scalar_vars_map.at(global_variable_index)->get_hessian(q_point);
     }
   else
     {
@@ -380,8 +377,7 @@ variableContainer<dim, degree, T>::get_vector_value(
   if (varInfoList[global_variable_index].evaluation_flags &
       dealii::EvaluationFlags::values)
     {
-      return vector_vars_map.at(varInfoList[global_variable_index].variable_index)
-        ->get_value(q_point);
+      return vector_vars_map.at(global_variable_index)->get_value(q_point);
     }
   else
     {
@@ -401,8 +397,7 @@ variableContainer<dim, degree, T>::get_vector_gradient(
   if (varInfoList[global_variable_index].evaluation_flags &
       dealii::EvaluationFlags::gradients)
     {
-      return vector_vars_map.at(varInfoList[global_variable_index].variable_index)
-        ->get_gradient(q_point);
+      return vector_vars_map.at(global_variable_index)->get_gradient(q_point);
     }
   else
     {
@@ -422,8 +417,7 @@ variableContainer<dim, degree, T>::get_vector_hessian(
   if (varInfoList[global_variable_index].evaluation_flags &
       dealii::EvaluationFlags::hessians)
     {
-      return vector_vars_map.at(varInfoList[global_variable_index].variable_index)
-        ->get_hessian(q_point);
+      return vector_vars_map.at(global_variable_index)->get_hessian(q_point);
     }
   else
     {
@@ -564,8 +558,7 @@ variableContainer<dim, degree, T>::set_scalar_value_term_RHS(
   unsigned int global_variable_index,
   T            val)
 {
-  scalar_vars_map[varInfoList[global_variable_index].variable_index]
-    ->submit_value(val, q_point);
+  scalar_vars_map[global_variable_index]->submit_value(val, q_point);
 }
 
 template <int dim, int degree, typename T>
@@ -574,8 +567,7 @@ variableContainer<dim, degree, T>::set_scalar_gradient_term_RHS(
   unsigned int              global_variable_index,
   dealii::Tensor<1, dim, T> grad)
 {
-  scalar_vars_map[varInfoList[global_variable_index].variable_index]
-    ->submit_gradient(grad, q_point);
+  scalar_vars_map[global_variable_index]->submit_gradient(grad, q_point);
 }
 
 template <int dim, int degree, typename T>
@@ -584,8 +576,7 @@ variableContainer<dim, degree, T>::set_vector_value_term_RHS(
   unsigned int              global_variable_index,
   dealii::Tensor<1, dim, T> val)
 {
-  vector_vars_map[varInfoList[global_variable_index].variable_index]
-    ->submit_value(val, q_point);
+  vector_vars_map[global_variable_index]->submit_value(val, q_point);
 }
 
 template <int dim, int degree, typename T>
@@ -594,8 +585,7 @@ variableContainer<dim, degree, T>::set_vector_gradient_term_RHS(
   unsigned int              global_variable_index,
   dealii::Tensor<2, dim, T> grad)
 {
-  vector_vars_map[varInfoList[global_variable_index].variable_index]
-    ->submit_gradient(grad, q_point);
+  vector_vars_map[global_variable_index]->submit_gradient(grad, q_point);
 }
 
 template <int dim, int degree, typename T>


### PR DESCRIPTION
The change variables were hard coded so that only the first `TIME_INDEPENDENT` equation would have its change variable (for Newton-Picard iteration). This prevented the addition of multiple `TIME_INDEPENDENT` (#166) equations. To fix this, I switched the `FEEvaluation` vectors to unordered maps instead.

This way, we can assign the `FEEvaluation` to the global variable index rather than the index of variable type (e.g. phi might be the 4th explicit variable and the 5th global variable. In the prior scheme we would index based on the 4th explicit). Doing so also reduced the convolutedness of `loadVariableAttributes.cc` and `variableContainer.cc`. 

Some minor optimizations were also made in regard to dereferencing over and over. Before we had this
```
scalar_vars_map[var_index]->reinit(cell);
scalar_vars_map[var_index]->read_dof_values(*src[i]);
scalar_vars_map[var_index]->evaluate(varInfoList[i].evaluation_flags);
```
Instead, I stored the pointer in a local variable.
```
auto *scalar_FEEval_ptr = scalar_vars_map[var_index].get();
scalar_FEEval_ptr->reinit(cell);
scalar_FEEval_ptr->read_dof_values(*src[i]);
scalar_FEEval_ptr->evaluate(var_info.evaluation_flags);
```
Since these are called for every cell and every step, the performance improvement should be rather significant.