### PR TITLE
Improved file reading using vtk rectilinear mesh

### DIFF
--- a/include/IntegrationTools/pfield/Body.hh
+++ b/include/IntegrationTools/pfield/Body.hh
@@ -1,4 +1,3 @@
-
 #ifndef Body_HH
 #define Body_HH
 
@@ -40,7 +39,7 @@ namespace PRISMS
         ///
         void read_vtk( const std::string &vtkfile)
         {
-            std::cout << "Begin reading vtk file" << std::endl;
+            std::cout << "Begin reading unstructured vtk file" << std::endl;
 
 
             // read in vtk file here
@@ -48,21 +47,22 @@ namespace PRISMS
 
             // read mesh info
             mesh.read_vtk(infile_mesh);
-
+           
+            
             std::ifstream infile(vtkfile.c_str());
 
             // read point data
             std::istringstream ss;
             std::string str, name, type, line;
             int numcomp;
-            unsigned long int Npoints;
-
+            unsigned long int Npoints, u, p;
+        
             while(!infile.eof())
             {
 
                 std::getline( infile, line);
-
-                if( line[0] == 'P')
+                
+             if( line[0] == 'P')
                 {
                     if( line.size() > 9 && line.substr(0,10) == "POINT_DATA")
                     {
@@ -72,8 +72,10 @@ namespace PRISMS
                         ss >> str >> Npoints;
 
                     }
-                }
-                else if( line[0] == 'S')
+                } 
+                
+            
+            if( line[0] == 'S')
                 {
                     if( line.size() > 6 && line.substr(0,7) == "SCALARS")
                     {
@@ -86,99 +88,248 @@ namespace PRISMS
 
                         // read data
                         std::cout << "begin reading data" << std::endl;
-                        std::vector<double> data(Npoints);
+                            
+                        std::vector<double> gid(Npoints);
                         for( unsigned int i=0; i<Npoints; i++)
                         {
-                            infile >> data[i];
+                            infile >> gid[i];
                             //std::cout << data[i] << std::endl;
                         }
                         std::cout << "  done" << std::endl;
-
-
+                        
                         // construct field
                         std::vector<std::string> var_name(DIM);
                         std::vector<std::string> var_description(DIM);
 
-                        if( DIM >= 2)
-                        {
-                            var_name[0] = "x";
-                            var_description[0] = "x coordinate";
-                            var_name[1] = "y";
-                            var_description[1] = "y coordinate";
+            if( DIM == 2)
+            {
+                var_name[0] = "x";
+                var_description[0] = "x coordinate";
+                var_name[1] = "y";
+                var_description[1] = "y coordinate";
 
-                        }
-                        if( DIM >= 3)
-                        {
-                            var_name[2] = "z";
-                            var_description[2] = "z coordinate";
+            }
+            if( DIM > 2)
+            {
+                var_name[2] = "z";
+                var_description[2] = "z coordinate";
 
-                        }
+            }
 
 
                         std::cout << "Construct PField '" << name << "'" << std::endl;
-                        scalar_field.push_back( PField<Coordinate, double, DIM>( name, var_name, var_description, mesh, data, 0.0) );
+                        scalar_field.push_back( PField<Coordinate, double, DIM>( name, var_name, var_description, mesh, gid, 0.0) );
                         std::cout << "  done" << std::endl;
-
+                
+                gid.clear();
+            //    
                     }
                 }
-                // Alternative field descriptor used by ParaView (holds the same information as the "SCALAR" line above)
-                else if( line[0] == 'F')
+            
+            }
+
+            infile.close();
+            
+            
+        }
+
+        void read_RL_vtk( const std::string &vtkfile)
+        {
+            std::cout << "Begin reading vtk file" << std::endl;
+
+
+            // read in vtk file here
+            std::ifstream infile_mesh(vtkfile.c_str());
+
+            // read mesh info
+            mesh.read_RL_vtk(infile_mesh);
+           
+            
+            std::ifstream infile(vtkfile.c_str());
+
+            // read point data
+            std::istringstream ss;
+            std::string str, name, type, line;
+            int numcomp;
+            unsigned long int N_points, Npoints_x, Npoints_y, Npoints_z, Npoints, u, p;
+        
+            while(!infile.eof())
+            {
+
+                std::getline( infile, line);
+                
+                       if( line[0] == 'X')
+            {
+
+                if( line.size() > 12 && line.substr(0,13) == "X_COORDINATES")
                 {
-                    if( line.size() > 14 && line.substr(0,15) == "FIELD FieldData")
+                    // read header line
+                    //std::cout << line << "\n";
+                    ss.clear();
+                    ss.str(line);
+                    ss >> str >> Npoints_x >> type;
+
+                    std::cout << "Read X_COORDINATES: " << Npoints_x << std::endl;
+           
+             //       std::cout << "  reserve OK" << std::endl;
+                }
+            }
+            if( line[0] == 'Y')
+            {
+
+                if( line.size() > 12 && line.substr(0,13) == "Y_COORDINATES")
+                {
+
+
+                    // read header line
+                    //std::cout << line << "\n";
+                    ss.clear();
+                    ss.str(line);
+                    ss >> str >> Npoints_y >> type;
+
+                    // read points
+                
+                    std::cout << "Read Y_COORDINATES: " << Npoints_y << std::endl;
+
+            //        std::cout << "  reserve OK" << std::endl;
+                }
+            }
+            if( line[0] == 'Z')
+            {
+
+                if( line.size() > 12 && line.substr(0,13) == "Z_COORDINATES")
+                {
+
+
+                    // read header line
+                    //std::cout << line << "\n";
+                    ss.clear();
+                    ss.str(line);
+                    ss >> str >> Npoints_z >> type;
+
+                    // read points
+
+                    std::cout << "Read Z_COORDINATES: " << Npoints_z << std::endl;
+
+                 //   std::cout << "  reserve OK" << std::endl;
+                }
+            } 
+                
+            
+            if( line[0] == 'S')
+                {
+                    if( line.size() > 6 && line.substr(0,7) == "SCALARS")
                     {
                         ss.clear();
                         ss.str(line);
-                        ss >> str >> numcomp;
+                        ss >> str >> name >> type >> numcomp;
 
                         // read LOOKUP_TABLE line
                         std::getline( infile, line);
 
-                        ss.clear();
-                        ss.str(line);
-                        ss >> name >> numcomp >> Npoints >> type;
-
-
                         // read data
                         std::cout << "begin reading data" << std::endl;
-                        std::vector<double> data(Npoints);
-                        for( unsigned int i=0; i<Npoints; i++)
+                        
+                        N_points = (Npoints_x)*(Npoints_y)*(Npoints_z);
+                        
+            if(DIM>2){
+                Npoints = 8*(Npoints_x-1)*(Npoints_y-1)*(Npoints_z-1);
+               }
+            if(DIM==2){
+                Npoints = 4*(Npoints_x-1)*(Npoints_y-1); 
+            }   
+                        
+                        std::vector<float> data(N_points); // NB: data and gid are of different size
+                        std::vector<double> gid(Npoints);   // gid is the grainID for each node     
+                       // unsigned int gid[Npoints];
+                        
+                        for( unsigned int i=0; i<N_points; i++)
                         {
                             infile >> data[i];
+                            //std::cout << data[i] << std::endl;
                         }
-                        std::cout << "  done" << std::endl;
-
-
+                        
+                        std::cout << "beginning grain_id stencil" << std::endl; 
+                        
+                        u = 0;
+            if(DIM>2){
+                    for (unsigned int i=0; i<(Npoints_z-1); i++){
+                        for (unsigned int j=0; j<(Npoints_y-1); j++){
+                            for (unsigned int k=0; k<(Npoints_x-1); k++){
+                                
+                                p = k + j*Npoints_x + i*Npoints_x*Npoints_y;
+                                
+                                gid[u] = data[p];
+                                gid[u+1] = data[p+1];
+                                gid[u+2] = data[p+Npoints_x];
+                                gid[u+3] = data[p+Npoints_x+1];
+                                gid[u+4] = data[p+Npoints_x*Npoints_y];
+                                gid[u+5] = data[p+Npoints_x*Npoints_y + 1];
+                                gid[u+6] = data[p+Npoints_x + Npoints_x*Npoints_y];
+                                gid[u+7] = data[p+Npoints_x + Npoints_x*Npoints_y + 1];
+                                
+                                u+=8;
+                            }
+                        }
+                    }
+            }
+            
+            if(DIM==2){
+                        for (unsigned int j=0; j<(Npoints_y-1); j++){
+                            for (unsigned int k=0; k<(Npoints_x-1); k++){
+                                
+                                p = k + j*Npoints_x;
+                                
+                                gid[u] = data[p];
+                                gid[u+1] = data[p+1];
+                                gid[u+2] = data[p+Npoints_x];
+                                gid[u+3] = data[p+Npoints_x+1];
+                                
+                                u+=4;
+                            }
+                        }
+            }
+            
+            
+                        data.clear();
+                    //    MPI_Barrier(MPI_COMM_WORLD);
+                        
                         // construct field
                         std::vector<std::string> var_name(DIM);
                         std::vector<std::string> var_description(DIM);
 
-                        if( DIM >= 2)
-                        {
-                            var_name[0] = "x";
-                            var_description[0] = "x coordinate";
-                            var_name[1] = "y";
-                            var_description[1] = "y coordinate";
+            if( DIM == 2)
+            {
+                var_name[0] = "x";
+                var_description[0] = "x coordinate";
+                var_name[1] = "y";
+                var_description[1] = "y coordinate";
 
-                        }
-                        if( DIM >= 3)
-                        {
-                            var_name[2] = "z";
-                            var_description[2] = "z coordinate";
+            }
+            if( DIM > 2)
+            {
+                var_name[2] = "z";
+                var_description[2] = "z coordinate";
 
-                        }
+            }
 
 
                         std::cout << "Construct PField '" << name << "'" << std::endl;
-                        scalar_field.push_back( PField<Coordinate, double, DIM>( name, var_name, var_description, mesh, data, 0.0) );
+                        scalar_field.push_back( PField<Coordinate, double, DIM>( name, var_name, var_description, mesh, gid, 0.0) );
                         std::cout << "  done" << std::endl;
-
+                
+                gid.clear();
+            //    
                     }
                 }
+            
             }
 
             infile.close();
+            
+            
         }
-
+        
         PField<Coordinate, double, DIM>& find_scalar_field(std::string name)
         {
             for( unsigned int i=0; i<scalar_field.size(); i++)

--- a/include/IntegrationTools/pfield/Coordinate.hh
+++ b/include/IntegrationTools/pfield/Coordinate.hh
@@ -13,7 +13,7 @@ namespace PRISMS
     template<int DIM>
     class Coordinate
     {
-        double _coord[DIM];
+      float _coord[DIM];
     public:
     
         
@@ -22,12 +22,12 @@ namespace PRISMS
             return DIM;
         }
         
-        double& operator[](int i)
+        float& operator[](int i)
         {
             return _coord[i];
         }
         
-        const double& operator[](int i) const
+        const float& operator[](int i) const
         {
             return _coord[i];
         }

--- a/include/IntegrationTools/pfield/Coordinate.hh
+++ b/include/IntegrationTools/pfield/Coordinate.hh
@@ -13,7 +13,7 @@ namespace PRISMS
     template<int DIM>
     class Coordinate
     {
-      float _coord[DIM];
+      float _coord[DIM]; // floating point precision is good enough for coordinates, it also reduces the memory usage
     public:
     
         

--- a/include/IntegrationTools/pfield/Mesh.hh
+++ b/include/IntegrationTools/pfield/Mesh.hh
@@ -47,7 +47,7 @@ namespace PRISMS
                                         const std::string &name,
                                         unsigned long int cell,
                                         PFuncBase<std::vector<PRISMS::Coordinate<2> >, double>* bfunc_ptr,
-                                        const std::vector<unsigned long int> &cell_node,
+                                        const std::vector<unsigned int> &cell_node,
                                         const std::vector<PRISMS::Coordinate<2> > &node)
     {
         if( name == "Quad")
@@ -80,7 +80,7 @@ namespace PRISMS
                                         const std::string &name,
                                         unsigned long int cell,
                                         PFuncBase<std::vector<PRISMS::Coordinate<3> >, double>* bfunc_ptr,
-                                        const std::vector<unsigned long int> &cell_node,
+                                        const std::vector<unsigned int> &cell_node,
                                         const std::vector<PRISMS::Coordinate<3> > &node)
     {
         if( name == "Hexahedron")
@@ -157,28 +157,32 @@ namespace PRISMS
                 delete _bfunc[i];
             }
         };
-
-        // reads vtk file through 'CELL_TYPES' and then returns
+        
         void read_vtk(std::ifstream &infile)
         {
-            bool mesh_as_points = true;
-            std::vector<double> x_coord, y_coord, z_coord;
-
+            std::cout << "Read unstructured mesh" << std::endl;
+            
             std::istringstream ss;
             std::string line, str, type;
 
-            unsigned long int uli_dummy;
+            unsigned int uli_dummy;
             double d_dummy;
 
-            unsigned long int Npoints, Ncells, Ncell_numbers;
-            std::vector<unsigned long int> cell_node;
+            unsigned long int Npoints, Ncells, Ncell_numbers, u;
+            std::vector<unsigned int> cell_node;
 
             PRISMS::Coordinate<DIM> _coord;
-
+            
+            std::vector<double> min;
+            std::vector<int> N;
+            std::vector<double> incr;
+           
+            
             while(!infile.eof())
             {
                 std::getline( infile, line);
                 //std::cout << "line: " << line << std::endl;
+            
 
                 if( line[0] == 'P')
                 {
@@ -198,7 +202,7 @@ namespace PRISMS
                         // read points
                         std::vector< std::vector<double> > value(DIM);
                         std::vector< std::vector<int> > hist(DIM);
-
+                        
                         std::cout << "Read POINTS: " << Npoints << std::endl;
                         _node.reserve(Npoints);
                         std::cout << "  reserve OK" << std::endl;
@@ -214,7 +218,7 @@ namespace PRISMS
                                 infile >> _coord[0] >> _coord[1] >> _coord[2];
                                 //std::cout << _coord[0] << " " << _coord[1] << " " << _coord[3] << std::endl;
                             }
-
+                            
                             for( int j=0; j<DIM; j++)
                             add_once( value[j], hist[j], _coord[j]);
                             _node.push_back(_coord);
@@ -222,26 +226,11 @@ namespace PRISMS
                         std::cout << "  done" << std::endl;
 
                         // create bins
-                        std::vector<double> min;
-                        std::vector<int> N;
-                        std::vector<double> incr;
-
+                       
                         std::cout << "Determine Body size" << std::endl;
                         for( int j=0; j<DIM; j++)
                         {
-                            for( unsigned int i=1; i<hist[j].size(); i++)
-                            {
-                                /*if( hist[j][i] != hist[j][i-1])
-                                {
-                                std::cout << "Error reading 2D vtk file." << std::endl;
-                                std::cout << "  Not rectangular." << std::endl;
-                                std::cout << "  Dimension: " << j << std::endl;
-                                std::cout << value[j][i-1] << ": " << hist[j][i-1] << "  " << value[j][i] << ": " << hist[j][i] << std::endl;
-                                exit(1);
-                            }
-                            */
-                        }
-
+                           
                         std::sort( value[j].begin(), value[j].end());
                         //std::cout << "j: " << j << " back(): " << value[j].back() << std::endl;
                         min.push_back( value[j][0]);
@@ -256,25 +245,26 @@ namespace PRISMS
                         min[j] -= incr[j];
                         N[j] += 2;
                     }
-                    std::cout << "  Min Coordinate: ";
-                    for( int j=0; j<DIM; j++)
-                    std::cout << _min[j] << " ";
-                    std::cout << std::endl;
-                    std::cout << "  Max Coordinate: ";
-                    for( int j=0; j<DIM; j++)
-                    std::cout << _max[j] << " ";
-                    std::cout << std::endl;
-
-                    std::cout << "  done" << std::endl;
-
-                    std::cout << "Initialize Bin" << std::endl;
-                    _bin = Bin<Interpolator<Coordinate, DIM>*, Coordinate>(min, incr, N);
-                    std::cout << "  done" << std::endl;
+                        std::cout << "  Min Coordinate: ";
+                        for( int j=0; j<DIM; j++)
+                        std::cout << _min[j] << " ";
+                        std::cout << std::endl;
+                        std::cout << "  Max Coordinate: ";
+                        for( int j=0; j<DIM; j++)
+                        std::cout << _max[j] << " ";
+                        std::cout << std::endl;
+    
+                        std::cout << "  done" << std::endl;
+    
+                        std::cout << "Initialize Bin" << std::endl;
+                        _bin = Bin<Interpolator<Coordinate, DIM>*, Coordinate>(min, incr, N);
+                        std::cout << "  done" << std::endl;
 
                 }
 
 
-            }
+            } 
+            
             else if( line[0] == 'C')
             {
 
@@ -365,15 +355,42 @@ namespace PRISMS
                 }
 
             }
-            if( line[0] == 'X')
-            {
-                mesh_as_points = false;
+            
+        }
 
-                // read X_COORDINATES info:
-                // X_COORDINATES # type
-                // x
-                // x
-                // ...
+}
+
+        //main code reading the RL coordinates and constructing cells and connectivity similar to unstructured grid
+        void read_RL_vtk(std::ifstream &infile)
+        {
+            std::cout << "Read rectilinear file and create mesh" << std::endl;
+            
+            bool mesh_as_points = true;
+            std::vector<float> x_coord, y_coord, z_coord;
+
+            std::istringstream ss;
+            std::string line, str, type;
+
+            unsigned int uli_dummy;
+            double d_dummy;
+
+            unsigned long int Npoints, Ncells, Ncell_numbers, u;
+            std::vector<unsigned int> cell_node;
+
+            PRISMS::Coordinate<DIM> _coord;
+            
+            std::vector<double> min;
+            std::vector<int> N;
+            std::vector<double> incr;
+           
+            
+            while(!infile.eof())
+            {
+                std::getline( infile, line);
+                //std::cout << "line: " << line << std::endl;
+                            if( line[0] == 'X')
+            {
+
                 if( line.size() > 12 && line.substr(0,13) == "X_COORDINATES")
                 {
                     // read header line
@@ -383,11 +400,10 @@ namespace PRISMS
                     ss >> str >> Npoints >> type;
 
                     std::cout << "Read X_COORDINATES: " << Npoints << std::endl;
-                    _node.reserve(Npoints);
                     std::cout << "  reserve OK" << std::endl;
                     for( unsigned int i=0; i<Npoints; i++)
                     {
-                        double temp_coord;
+                        float temp_coord;
 
                         infile >> temp_coord;
 
@@ -398,13 +414,7 @@ namespace PRISMS
             }
             if( line[0] == 'Y')
             {
-                mesh_as_points = false;
 
-                // read Y_COORDINATES info:
-                // Y_COORDINATES # type
-                // y
-                // y
-                // ...
                 if( line.size() > 12 && line.substr(0,13) == "Y_COORDINATES")
                 {
 
@@ -416,15 +426,13 @@ namespace PRISMS
                     ss >> str >> Npoints >> type;
 
                     // read points
-                    std::vector< std::vector<double> > value(DIM);
-                    std::vector< std::vector<int> > hist(DIM);
-
+                
                     std::cout << "Read Y_COORDINATES: " << Npoints << std::endl;
-                    _node.reserve(Npoints);
+                
                     std::cout << "  reserve OK" << std::endl;
                     for( unsigned int i=0; i<Npoints; i++)
                     {
-                        double temp_coord;
+                        float temp_coord;
 
                         infile >> temp_coord;
 
@@ -435,13 +443,7 @@ namespace PRISMS
             }
             if( line[0] == 'Z')
             {
-                mesh_as_points = false;
 
-                // read Z_COORDINATES info:
-                // Z_COORDINATES # type
-                // z
-                // z
-                // ...
                 if( line.size() > 12 && line.substr(0,13) == "Z_COORDINATES")
                 {
 
@@ -455,11 +457,11 @@ namespace PRISMS
                     // read points
 
                     std::cout << "Read Z_COORDINATES: " << Npoints << std::endl;
-                    _node.reserve(Npoints);
+                
                     std::cout << "  reserve OK" << std::endl;
                     for( unsigned int i=0; i<Npoints; i++)
                     {
-                        double temp_coord;
+                        float temp_coord;
 
                         infile >> temp_coord;
 
@@ -468,52 +470,121 @@ namespace PRISMS
                     }
                 }
             }
+            }
+            
+                 if(mesh_as_points){
+            
+           std::vector< std::vector<double> > value(DIM);
+           std::vector< std::vector<int> > hist(DIM);
+           
+            if(DIM >2){
+            Npoints = 8*(x_coord.size()-1)*(y_coord.size()-1)*(z_coord.size()-1);
+            } 
+            if(DIM ==2){
+                Npoints = 4*(x_coord.size()-1)*(y_coord.size()-1);
+            }
+            
+            //interpolated coordinates for each node of a cell
+            std::vector<float> COORD_X(Npoints), COORD_Y(Npoints), COORD_Z(Npoints);
+             
+            u = 0; //(defined at the beginning of read_vtk)
+        if(DIM>2) {
+            for (unsigned int i=0; i<(z_coord.size()-1); i++){
+                for (unsigned int j=0; j<(y_coord.size()-1); j++){
+                    for (unsigned int k=0; k<(x_coord.size()-1); k++){
+                        
+                      COORD_X[u] = x_coord.at(k);
+                      COORD_Y[u] = y_coord.at(j);
+                      COORD_Z[u] = z_coord.at(i);
+                      
+                      COORD_X[u+1] = x_coord.at(k+1);
+                      COORD_Y[u+1] = y_coord.at(j);
+                      COORD_Z[u+1] = z_coord.at(i);
+                      
+                      COORD_X[u+2] = x_coord.at(k);
+                      COORD_Y[u+2] = y_coord.at(j+1);
+                      COORD_Z[u+2] = z_coord.at(i);
+                      
+                      COORD_X[u+3] = x_coord.at(k+1);
+                      COORD_Y[u+3] = y_coord.at(j+1);
+                      COORD_Z[u+3] = z_coord.at(i);
+                      
+                      COORD_X[u+4] = x_coord.at(k);
+                      COORD_Y[u+4] = y_coord.at(j);
+                      COORD_Z[u+4] = z_coord.at(i+1);
+                      
+                      COORD_X[u+5] = x_coord.at(k+1);
+                      COORD_Y[u+5] = y_coord.at(j);
+                      COORD_Z[u+5] = z_coord.at(i+1);
+                      
+                      COORD_X[u+6] = x_coord.at(k);
+                      COORD_Y[u+6] = y_coord.at(j+1);
+                      COORD_Z[u+6] = z_coord.at(i+1);
+                      
+                      COORD_X[u+7] = x_coord.at(k+1);
+                      COORD_Y[u+7] = y_coord.at(j+1);
+                      COORD_Z[u+7] = z_coord.at(i+1);
+                      
+                      u+= 8;
+                    }
+                }
+            }
+            
         }
-
-        if (!mesh_as_points){
-            std::vector< std::vector<double> > value(DIM);
-            std::vector< std::vector<int> > hist(DIM);
-
-            for (unsigned int i=0; i<x_coord.size(); i++){
-                for (unsigned int j=0; j<y_coord.size(); j++){
-                    for (unsigned int k=0; k<z_coord.size(); k++){
-                        _coord[0] = x_coord.at(i);
-                        _coord[1] = y_coord.at(j);
-                        if (DIM > 2){
-                            _coord[2] = z_coord.at(k);
-                        }
-
+        
+        if(DIM==2) {
+                for (unsigned int j=0; j<(y_coord.size()-1); j++){
+                    for (unsigned int k=0; k<(x_coord.size()-1); k++){
+                        
+                      COORD_X[u] = x_coord.at(k);
+                      COORD_Y[u] = y_coord.at(j);
+                      COORD_Z[u] = z_coord.at(0);
+                      
+                      COORD_X[u+1] = x_coord.at(k+1);
+                      COORD_Y[u+1] = y_coord.at(j);
+                      COORD_Z[u+1] = z_coord.at(0);
+                      
+                      COORD_X[u+2] = x_coord.at(k);
+                      COORD_Y[u+2] = y_coord.at(j+1);
+                      COORD_Z[u+2] = z_coord.at(0);
+                      
+                      COORD_X[u+3] = x_coord.at(k+1);
+                      COORD_Y[u+3] = y_coord.at(j+1);
+                      COORD_Z[u+3] = z_coord.at(0);
+                      
+                      u+= 4;
+                    }
+                }
+        }
+            
+            // _node.reserve(Npoints);
+            for( unsigned int i=0; i<Npoints; i++)
+                        {
+                         
+                        _coord[0] = COORD_X[i];
+                        _coord[1] = COORD_Y[i];
+                        _coord[2] = COORD_Z[i];
+                        
                         for( int m=0; m<DIM; m++)
                         add_once( value[m], hist[m], _coord[m]);
 
                         _node.push_back(_coord);
-                    }
-                }
+                
             }
-
-
-            std::cout << "  done" << std::endl;
-
-            // create bins
-            std::vector<double> min;
-            std::vector<int> N;
-            std::vector<double> incr;
-
+          
+           
+            x_coord.clear();
+            y_coord.clear();
+            z_coord.clear(); 
+            COORD_X.clear();
+            COORD_Y.clear();
+            COORD_Z.clear(); 
+            
+            std::cout << "point coordinates done" << std::endl;
+           
             std::cout << "Determine Body size" << std::endl;
             for( int j=0; j<DIM; j++)
             {
-                for( unsigned int i=1; i<hist[j].size(); i++)
-                {
-                    /*if( hist[j][i] != hist[j][i-1])
-                    {
-                    std::cout << "Error reading 2D vtk file." << std::endl;
-                    std::cout << "  Not rectangular." << std::endl;
-                    std::cout << "  Dimension: " << j << std::endl;
-                    std::cout << value[j][i-1] << ": " << hist[j][i-1] << "  " << value[j][i] << ": " << hist[j][i] << std::endl;
-                    exit(1);
-                }
-                */
-            }
 
             std::sort( value[j].begin(), value[j].end());
             //std::cout << "j: " << j << " back(): " << value[j].back() << std::endl;
@@ -543,11 +614,14 @@ namespace PRISMS
         std::cout << "Initialize Bin" << std::endl;
         _bin = Bin<Interpolator<Coordinate, DIM>*, Coordinate>(min, incr, N);
         std::cout << "  done" << std::endl;
-
+         
         // Now add the cell data
-        unsigned int Ncells = (x_coord.size()-1) * (y_coord.size()-1);
-        if (DIM > 2){
-            Ncells *= (z_coord.size()-1);
+       // unsigned int Ncells = (x_coord.size()-1) * (y_coord.size()-1);
+        if( DIM == 2)
+        {
+       Ncells =  (_node.size()/4);
+        } else if( DIM > 2){
+            Ncells =  (_node.size()/8);
         }
 
         PFuncBase<std::vector<PRISMS::Coordinate<DIM> >, double>* bfunc_ptr;
@@ -556,29 +630,30 @@ namespace PRISMS
         if( DIM == 2)
         {
             // add Quad basis function
-            _interp.reserve(Ncells*4);
+        //    _interp.reserve(Ncells*4);
             construct_basis_function(_bfunc.back(), "Quad");
         }
-        else if( DIM == 3)
+        else if( DIM > 2)
         {
             // add Hexahedron basis function
-            _interp.reserve(Ncells*8);
+        //    _interp.reserve(Ncells*8);
             construct_basis_function(_bfunc.back(), "Hexahedron");
         }
         bfunc_ptr = _bfunc.back();
 
         std::cout << "Read CELLS: " << Ncells << std::endl;
 
-        unsigned int uli_dummy;
         if (DIM > 2){
             uli_dummy = 8;
         }
         else {
             uli_dummy = 4;
         }
+        
+        cell_node.reserve(uli_dummy);
         for( unsigned int i=0; i<Ncells; i++)
         {
-            cell_node.resize(uli_dummy);
+            
             for( unsigned int j=0; j<uli_dummy; j++)
             {
                 cell_node[j] = i*uli_dummy+j;
@@ -586,11 +661,13 @@ namespace PRISMS
 
             if( DIM == 2)
             {
-                double temp = cell_node[2];
-                cell_node[2] = cell_node[3];
-                cell_node[3] = temp;
+                std::swap(cell_node[2],cell_node[3]);
+                      }
+             if( DIM > 2)
+            {
+                std::swap(cell_node[2],cell_node[3]);
+                std::swap(cell_node[6],cell_node[7]);
             }
-
             //std::cout << cell_node[0] << " " << cell_node[1] << " " << cell_node[2] << " " << cell_node[3] << std::endl;
 
             // create interpolator
@@ -598,27 +675,28 @@ namespace PRISMS
             {
                 construct_interpolating_functions(_interp, "Quad", i, bfunc_ptr, cell_node, _node);
             }
-            else if(DIM == 3)
+            else if(DIM > 2)
             {
                 construct_interpolating_functions(_interp, "Hexahedron", i, bfunc_ptr, cell_node, _node);
             }
 
         }
-        std::cout << "  done" << std::endl;
-
+        std::cout << "cell creation done" << std::endl;
+        
         // bin interpolators
         std::cout << "Bin interpolating functions" << std::endl;
         std::cout << "num nodes: " << _node.size() << std::endl;
         for( unsigned int i=0; i<_interp.size(); i++)
         {
-            std::cout << "interp: " << _interp[i] << " " << _interp[i]->min() << " " << _interp[i]->max() << std::endl;
+        //     std::cout << "interp: " << _interp[i] << " " << _interp[i]->min() << " " << _interp[i]->max() << std::endl;
             _bin.add_range(_interp[i], _interp[i]->min(), _interp[i]->max());
         }
         std::cout << "  done  max_bin_size: " << _bin.max_size() << std::endl;
 
-    }
-
-
+             
+         }    
+            
+            
 }
 
         void min( Coordinate &coord)
@@ -793,7 +871,6 @@ namespace PRISMS
 
         }
     };
-
 }
 
 

--- a/include/IntegrationTools/pfield/PField.hh
+++ b/include/IntegrationTools/pfield/PField.hh
@@ -5,6 +5,7 @@
 #include "../pfunction/PFuncBase.hh"
 #include "./Mesh.hh"
 
+
 //_name(name),
 //_var_name(var_name),
 //_var_description(var_description),

--- a/include/userInputParameters.h
+++ b/include/userInputParameters.h
@@ -250,6 +250,7 @@ public:
   double                    buffer_between_grains;
 
   bool         load_grain_structure;
+  bool         load_unstructured_grid;
   double       min_radius_for_loading_grains;
   std::string  grain_structure_filename;
   std::string  grain_structure_variable_name;

--- a/src/inputFileReader/inputFileReader.cc
+++ b/src/inputFileReader/inputFileReader.cc
@@ -730,7 +730,7 @@ inputFileReader::declare_parameters(dealii::ParameterHandler    &parameter_handl
     "The filename (not including the '.vtk' extension) for the file holding "
     "the grain structure to be loaded.");
     
-  parameter_handler.declare_entry("Load as unstructured grid","false",dealii::Patterns::Bool(),"Whether to load a unstructured file for grain structure.");
+  parameter_handler.declare_entry("Load as unstructured grid","true",dealii::Patterns::Bool(),"Whether to load a unstructured file for grain structure.");
 
   parameter_handler.declare_entry(
     "Grain structure variable name",

--- a/src/inputFileReader/inputFileReader.cc
+++ b/src/inputFileReader/inputFileReader.cc
@@ -729,6 +729,8 @@ inputFileReader::declare_parameters(dealii::ParameterHandler    &parameter_handl
     dealii::Patterns::Anything(),
     "The filename (not including the '.vtk' extension) for the file holding "
     "the grain structure to be loaded.");
+    
+  parameter_handler.declare_entry("Load as unstructured grid","false",dealii::Patterns::Bool(),"Whether to load a unstructured file for grain structure.");
 
   parameter_handler.declare_entry(
     "Grain structure variable name",

--- a/src/matrixfree/initialConditions.cc
+++ b/src/matrixfree/initialConditions.cc
@@ -89,7 +89,12 @@ MatrixFreePDE<dim, degree>::applyInitialConditions()
       std::string filename = userInputs.grain_structure_filename;
       filename += ".vtk";
 
-      body.read_vtk(filename);
+      if (userInputs.load_unstructured_grid){
+        body.read_vtk(filename);
+         } else {
+         body.read_RL_vtk(filename);     
+         }
+         
       ScalarField &id_field =
         body.find_scalar_field(userInputs.grain_structure_variable_name);
 
@@ -357,7 +362,11 @@ MatrixFreePDE<dim, degree>::applyInitialConditions()
                 }
 
               // Load the data from the file using a PField
-              body.read_vtk(filename);
+               if (userInputs.load_unstructured_grid){
+                    body.read_vtk(filename);
+                     } else {
+                     body.read_RL_vtk(filename);     
+                     }
               ScalarField &conc =
                 body.find_scalar_field(userInputs.load_field_name[var_index]);
 

--- a/src/userInputParameters/userInputParameters.cc
+++ b/src/userInputParameters/userInputParameters.cc
@@ -597,6 +597,7 @@ userInputParameters<dim>::userInputParameters(inputFileReader          &input_fi
     }
 
   load_grain_structure          = parameter_handler.get_bool("Load grain structure");
+  load_unstructured_grid        = parameter_handler.get_bool("Load as unstructured grid");
   grain_structure_filename      = parameter_handler.get("Grain structure filename");
   grain_structure_variable_name = parameter_handler.get("Grain structure variable name");
   num_grain_smoothing_cycles    = parameter_handler.get_integer(


### PR DESCRIPTION
These commits are for external file reading with vtk rectilinear mesh. Currently only unstructured mesh can be read through the input file. However, many problems do not require unstructured mesh. Therefore, rectilinear mesh can reduce the file size and improve the memory usage while reading the files. The default option for file reading is set as unstructured mesh. If you want to read rectilinear file instead, include the following line just below "set Load grain structure" in your input parameter file:
**set Load as unstructured grid = false**

I compiled the code and it worked for me, hopefully this can be merged with the master.