### PR TITLE
Fixed warnings on application level

### DIFF
--- a/applications/CHAC_anisotropy/ICs_and_BCs.cc
+++ b/applications/CHAC_anisotropy/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -52,12 +52,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/CHAC_anisotropy/customPDE.h
+++ b/applications/CHAC_anisotropy/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/CHAC_anisotropy/equations.cc
+++ b/applications/CHAC_anisotropy/equations.cc
@@ -49,8 +49,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -149,8 +149,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -171,6 +171,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/CHAC_anisotropy/postprocess.cc
+++ b/applications/CHAC_anisotropy/postprocess.cc
@@ -38,9 +38,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
   // c

--- a/applications/CHAC_anisotropyRegularized/ICs_and_BCs.cc
+++ b/applications/CHAC_anisotropyRegularized/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -56,12 +56,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/CHAC_anisotropyRegularized/customPDE.h
+++ b/applications/CHAC_anisotropyRegularized/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/CHAC_anisotropyRegularized/equations.cc
+++ b/applications/CHAC_anisotropyRegularized/equations.cc
@@ -57,8 +57,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -162,8 +162,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -193,6 +193,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/CHAC_anisotropyRegularized/postprocess.cc
+++ b/applications/CHAC_anisotropyRegularized/postprocess.cc
@@ -38,9 +38,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHAC_performance_test/ICs_and_BCs.cc
+++ b/applications/CHAC_performance_test/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -67,12 +67,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/CHAC_performance_test/customPDE.h
+++ b/applications/CHAC_performance_test/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================
@@ -79,8 +87,8 @@ private:
   double Mn = userInputs.get_model_constant_double("Mn");
   double Kn = userInputs.get_model_constant_double("Kn");
 
-  dealii::Tensor<1, dim> center1 = userInputs.get_model_constant_rank_1_tensor("center1");
-  dealii::Tensor<1, dim> center2 = userInputs.get_model_constant_rank_1_tensor("center2");
+  Tensor<1, dim> center1 = userInputs.get_model_constant_rank_1_tensor("center1");
+  Tensor<1, dim> center2 = userInputs.get_model_constant_rank_1_tensor("center2");
 
   double radius1 = userInputs.get_model_constant_double("radius1");
   double radius2 = userInputs.get_model_constant_double("radius2");

--- a/applications/CHAC_performance_test/equations.cc
+++ b/applications/CHAC_performance_test/equations.cc
@@ -49,8 +49,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -110,8 +110,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -132,6 +132,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/CHAC_performance_test/postprocess.cc
+++ b/applications/CHAC_performance_test/postprocess.cc
@@ -36,9 +36,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmark1a/ICs_and_BCs.cc
+++ b/applications/CHiMaD_benchmark1a/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -20,8 +20,7 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
     {
       double epsilon = 0.01;
       double c0      = 0.5;
-      double dx      = userInputs.domain_size[0] / ((double) userInputs.subdivisions[0]) /
-                  std::pow(2.0, userInputs.refine_factor);
+
       scalar_IC =
         c0 + epsilon * (std::cos(0.105 * p[0]) * std::cos(0.11 * p[1]) +
                         std::pow(std::cos(0.13 * p[0]) * std::cos(0.087 * p[1]), 2.0) +
@@ -42,12 +41,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/CHiMaD_benchmark1a/customPDE.h
+++ b/applications/CHiMaD_benchmark1a/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/CHiMaD_benchmark1a/equations.cc
+++ b/applications/CHiMaD_benchmark1a/equations.cc
@@ -49,8 +49,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -88,8 +88,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -132,6 +132,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/CHiMaD_benchmark1a/postprocess.cc
+++ b/applications/CHiMaD_benchmark1a/postprocess.cc
@@ -38,9 +38,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmark2a/ICs_and_BCs.cc
+++ b/applications/CHiMaD_benchmark2a/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -22,8 +22,6 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
   double epsilon_n = 0.1;
   double psi       = 1.5;
 
-  double dx = userInputs.domain_size[0] / ((double) userInputs.subdivisions[0]) /
-              std::pow(2.0, userInputs.refine_factor);
   double x = p[0];
   double y = p[1];
 
@@ -83,12 +81,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/CHiMaD_benchmark2a/customPDE.h
+++ b/applications/CHiMaD_benchmark2a/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/CHiMaD_benchmark2a/equations.cc
+++ b/applications/CHiMaD_benchmark2a/equations.cc
@@ -81,8 +81,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -105,19 +105,10 @@ customPDE<dim, degree>::explicitEquationRHS(
   // --- Setting the expressions for the terms in the governing equations ---
 
   // Free energy for each phase and their first and second derivatives
-  scalarvalueType faV   = (constV(2.0) * (c - constV(0.3)) * (c - constV(0.3)));
-  scalarvalueType facV  = (constV(4.0) * (c - constV(0.3)));
-  scalarvalueType faccV = (constV(4.0));
-  scalarvalueType fbV   = (constV(2.0) * (c - constV(0.7)) * (c - constV(0.7)));
-  scalarvalueType fbcV  = (constV(4.0) * (c - constV(0.7)));
-  scalarvalueType fbccV = (constV(4.0));
+  scalarvalueType faV = (constV(2.0) * (c - constV(0.3)) * (c - constV(0.3)));
+  scalarvalueType fbV = (constV(2.0) * (c - constV(0.7)) * (c - constV(0.7)));
 
   // Interpolation function and its derivatives
-  scalarvalueType hV =
-    (n1 * n1 * n1 * (constV(6.0) * n1 * n1 - constV(15.0) * n1 + constV(10.0)) +
-     n2 * n2 * n2 * (constV(6.0) * n2 * n2 - constV(15.0) * n2 + constV(10.0)) +
-     n3 * n3 * n3 * (constV(6.0) * n3 * n3 - constV(15.0) * n3 + constV(10.0)) +
-     n4 * n4 * n4 * (constV(6.0) * n4 * n4 - constV(15.0) * n4 + constV(10.0)));
   scalarvalueType hn1V =
     (n1 * n1 * (constV(30.0) * n1 * n1 - constV(60.0) * n1 + constV(30.0)));
   scalarvalueType hn2V =
@@ -126,19 +117,6 @@ customPDE<dim, degree>::explicitEquationRHS(
     (n3 * n3 * (constV(30.0) * n3 * n3 - constV(60.0) * n3 + constV(30.0)));
   scalarvalueType hn4V =
     (n4 * n4 * (constV(30.0) * n4 * n4 - constV(60.0) * n4 + constV(30.0)));
-
-  // Combined double-well and interaction functions (function g) and its
-  // derivatives Double-well part
-  scalarvalueType gdwV = (n1 * n1 * (constV(1.0) - n1) * (constV(1.0) - n1) +
-                          n2 * n2 * (constV(1.0) - n2) * (constV(1.0) - n2) +
-                          n3 * n3 * (constV(1.0) - n3) * (constV(1.0) - n3) +
-                          n4 * n4 * (constV(1.0) - n4) * (constV(1.0) - n4));
-  // Interaction part
-  scalarvalueType gintV =
-    (alpha * (n1 * n1 * n2 * n2 + n1 * n1 * n3 * n3 + n1 * n1 * n4 * n4 +
-              n2 * n2 * n3 * n3 + n2 * n2 * n4 * n4 + n3 * n3 * n4 * n4));
-  // Combined function (g)
-  // scalarvalueType gV = ( gdwV + gintV ); // Not actually needed
 
   // Derivatives
   scalarvalueType dgn1V =
@@ -204,8 +182,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -259,6 +237,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/CHiMaD_benchmark2a/postprocess.cc
+++ b/applications/CHiMaD_benchmark2a/postprocess.cc
@@ -40,9 +40,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmark3/ICs_and_BCs.cc
+++ b/applications/CHiMaD_benchmark3/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -59,12 +59,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/CHiMaD_benchmark3/customPDE.h
+++ b/applications/CHiMaD_benchmark3/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/CHiMaD_benchmark3/equations.cc
+++ b/applications/CHiMaD_benchmark3/equations.cc
@@ -57,8 +57,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -117,8 +117,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -152,7 +152,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
   scalarvalueType W_theta =
     constV(-W0) *
     (constV(epsilonM) * constV(mult) * std::sin(constV(mult) * (theta - constV(theta0))));
-  scalarvalueType tau = W / constV(W0);
 
   // The anisotropy term that enters in to the  equation for mu
   scalargradType aniso;
@@ -187,6 +186,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/CHiMaD_benchmark3/postprocess.cc
+++ b/applications/CHiMaD_benchmark3/postprocess.cc
@@ -38,9 +38,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmark6a/ICs_and_BCs.cc
+++ b/applications/CHiMaD_benchmark6a/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -48,12 +48,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE
@@ -71,7 +72,6 @@ customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
     {
       if (direction == 1)
         {
-          double x  = p[0];
           double y  = p[1];
           scalar_BC = std::sin(y / 7.0);
         }

--- a/applications/CHiMaD_benchmark6a/customPDE.h
+++ b/applications/CHiMaD_benchmark6a/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/CHiMaD_benchmark6a/equations.cc
+++ b/applications/CHiMaD_benchmark6a/equations.cc
@@ -59,8 +59,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -98,8 +98,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -151,8 +151,8 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmark6a/postprocess.cc
+++ b/applications/CHiMaD_benchmark6a/postprocess.cc
@@ -38,9 +38,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmark6b/ICs_and_BCs.cc
+++ b/applications/CHiMaD_benchmark6b/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -48,12 +48,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE
@@ -71,7 +72,6 @@ customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
     {
       if (direction == 1)
         {
-          double x  = p[0];
           double y  = p[1];
           scalar_BC = std::sin(y / 7.0);
         }

--- a/applications/CHiMaD_benchmark6b/customPDE.h
+++ b/applications/CHiMaD_benchmark6b/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================
@@ -73,7 +81,7 @@ private:
 
   // Virtual method in MatrixFreePDE
   void
-  makeTriangulation(parallel::distributed::Triangulation<dim> &) const;
+  makeTriangulation(parallel::distributed::Triangulation<dim> &) const override;
 
   // ================================================================
   // Model constants specific to this subclass
@@ -97,7 +105,7 @@ void
 customPDE<dim, degree>::makeTriangulation(
   parallel::distributed::Triangulation<dim> &tria) const
 {
-  dealii::parallel::distributed::Triangulation<dim> tria_box(MPI_COMM_WORLD),
+  parallel::distributed::Triangulation<dim> tria_box(MPI_COMM_WORLD),
     tria_semicircle(MPI_COMM_WORLD);
   if (dim == 3)
     {

--- a/applications/CHiMaD_benchmark6b/equations.cc
+++ b/applications/CHiMaD_benchmark6b/equations.cc
@@ -59,8 +59,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -98,8 +98,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -151,8 +151,8 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // grad(delta phi)
   scalargradType Dphix = variable_list.get_change_in_scalar_gradient(2);

--- a/applications/CHiMaD_benchmark6b/postprocess.cc
+++ b/applications/CHiMaD_benchmark6b/postprocess.cc
@@ -38,9 +38,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmark7/ICs_and_BCs.cc
+++ b/applications/CHiMaD_benchmark7/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -19,8 +19,6 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
   // The initial condition is a set of overlapping circles/spheres defined
   // by a hyperbolic tangent function. The center of each circle/sphere is
   // given by "center" and its radius is given by "radius".
-
-  double pi = 2.0 * std::acos(0.0);
 
   double r0    = 0.25 + A2 * std::sin(B2 * p(0));
   double delta = 1.0 / std::sqrt(kappa * 2.0);
@@ -36,12 +34,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/CHiMaD_benchmark7/customPDE.h
+++ b/applications/CHiMaD_benchmark7/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
   // ================================================================
   // Methods specific to this subclass

--- a/applications/CHiMaD_benchmark7/equations.cc
+++ b/applications/CHiMaD_benchmark7/equations.cc
@@ -41,8 +41,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -78,7 +78,7 @@ customPDE<dim, degree>::explicitEquationRHS(
            (alpha_y[i] * alpha_y[i]) +
          std::sqrt(2.0) * (alpha_t[i] - kappa * alpha_yy[i])) /
         (4.0 * std::sqrt(kappa)) /
-        dealii::Utilities::fixed_power<2>(
+        Utilities::fixed_power<2>(
           std::cosh((q_point_loc(1)[i] - alpha[i]) / std::sqrt(2.0 * kappa)));
     }
 
@@ -104,8 +104,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -126,6 +126,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/CHiMaD_benchmark7/postprocess.cc
+++ b/applications/CHiMaD_benchmark7/postprocess.cc
@@ -65,9 +65,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -120,7 +122,7 @@ customPDE<dim, degree>::postProcessedFields(
            (alpha_y[i] * alpha_y[i]) +
          std::sqrt(2.0) * (alpha_t[i] - kappa * alpha_yy[i])) /
         (4.0 * std::sqrt(kappa)) /
-        dealii::Utilities::fixed_power<2>(
+        Utilities::fixed_power<2>(
           std::cosh((q_point_loc(1)[i] - alpha[i]) / std::sqrt(2.0 * kappa)));
 
       n_sol[i] =

--- a/applications/MgNd_precipitate_single_Bppp/ICs_and_BCs.cc
+++ b/applications/MgNd_precipitate_single_Bppp/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -71,12 +71,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/MgNd_precipitate_single_Bppp/customPDE.h
+++ b/applications/MgNd_precipitate_single_Bppp/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -23,20 +25,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -47,36 +49,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================
@@ -87,16 +95,15 @@ private:
   // Model constants specific to this subclass
   // ================================================================
 
-  double                 McV  = userInputs.get_model_constant_double("McV");
-  double                 Mn1V = userInputs.get_model_constant_double("Mn1V");
-  dealii::Tensor<2, dim> Kn1  = userInputs.get_model_constant_rank_2_tensor("Kn1");
-  double                 W    = userInputs.get_model_constant_double("W");
-  bool                   n_dependent_stiffness =
+  double         McV  = userInputs.get_model_constant_double("McV");
+  double         Mn1V = userInputs.get_model_constant_double("Mn1V");
+  Tensor<2, dim> Kn1  = userInputs.get_model_constant_rank_2_tensor("Kn1");
+  double         W    = userInputs.get_model_constant_double("W");
+  bool           n_dependent_stiffness =
     userInputs.get_model_constant_bool("n_dependent_stiffness");
-  dealii::Tensor<2, dim> sfts_linear1 =
+  Tensor<2, dim> sfts_linear1 =
     userInputs.get_model_constant_rank_2_tensor("sfts_linear1");
-  dealii::Tensor<2, dim> sfts_const1 =
-    userInputs.get_model_constant_rank_2_tensor("sfts_const1");
+  Tensor<2, dim> sfts_const1 = userInputs.get_model_constant_rank_2_tensor("sfts_const1");
 
   double A2 = userInputs.get_model_constant_double("A2");
   double A1 = userInputs.get_model_constant_double("A1");
@@ -105,10 +112,10 @@ private:
   double B1 = userInputs.get_model_constant_double("B1");
   double B0 = userInputs.get_model_constant_double("B0");
 
-  const static unsigned int          CIJ_tensor_size = 2 * dim - 1 + dim / 3;
-  dealii::Tensor<2, CIJ_tensor_size> CIJ_Mg =
+  const static unsigned int  CIJ_tensor_size = 2 * dim - 1 + dim / 3;
+  Tensor<2, CIJ_tensor_size> CIJ_Mg =
     userInputs.get_model_constant_elasticity_tensor("CIJ_Mg");
-  dealii::Tensor<2, CIJ_tensor_size> CIJ_Beta =
+  Tensor<2, CIJ_tensor_size> CIJ_Beta =
     userInputs.get_model_constant_elasticity_tensor("CIJ_Beta");
 
   bool c_dependent_misfit;

--- a/applications/MgNd_precipitate_single_Bppp/equations.cc
+++ b/applications/MgNd_precipitate_single_Bppp/equations.cc
@@ -67,8 +67,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -102,11 +102,9 @@ customPDE<dim, degree>::explicitEquationRHS(
   scalarvalueType facV  = (2.0 * A2 * c_alpha + A1);
   scalarvalueType faccV = (constV(2.0) * A2);
   scalarvalueType fbV   = (B2 * c_beta * c_beta + B1 * c_beta + B0);
-  scalarvalueType fbcV  = (2.0 * B2 * c_beta + B1);
   scalarvalueType fbccV = (constV(2.0) * B2);
 
   // This double-well function can be used to tune the interfacial energy
-  scalarvalueType fbarrierV  = (n1 * n1 - 2.0 * n1 * n1 * n1 + n1 * n1 * n1 * n1);
   scalarvalueType fbarriernV = (2.0 * n1 - 6.0 * n1 * n1 + 4.0 * n1 * n1 * n1);
 
   // Calculate the derivatives of c_beta (derivatives of c_alpha aren't needed)
@@ -124,8 +122,7 @@ customPDE<dim, degree>::explicitEquationRHS(
 
   // Calculate the stress-free transformation strain and its derivatives at the
   // quadrature point
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts1n,
-    sfts1cn;
+  Tensor<2, dim, VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts1n, sfts1cn;
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -142,7 +139,7 @@ customPDE<dim, degree>::explicitEquationRHS(
     }
 
   // compute E2=(E-E0)
-  dealii::VectorizedArray<double> E2[dim][dim], S[dim][dim];
+  VectorizedArray<double> E2[dim][dim], S[dim][dim];
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -155,7 +152,7 @@ customPDE<dim, degree>::explicitEquationRHS(
   // compute stress
   // S=C*(E-E0)
   //  Compute stress tensor (which is equal to the residual, Rux)
-  dealii::VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
+  VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
 
   if (n_dependent_stiffness == true)
     {
@@ -176,7 +173,7 @@ customPDE<dim, degree>::explicitEquationRHS(
 
   // Compute one of the stress terms in the order parameter chemical potential,
   // nDependentMisfitACp = -C*(E-E0)*(E0_n)
-  dealii::VectorizedArray<double> nDependentMisfitAC1 = constV(0.0);
+  VectorizedArray<double> nDependentMisfitAC1 = constV(0.0);
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -188,8 +185,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 
   // Compute the other stress term in the order parameter chemical potential,
   // heterMechACp = 0.5*Hn*(C_beta-C_alpha)*(E-E0)*(E-E0)
-  dealii::VectorizedArray<double> heterMechAC1 = constV(0.0);
-  dealii::VectorizedArray<double> S2[dim][dim];
+  VectorizedArray<double> heterMechAC1 = constV(0.0);
+  VectorizedArray<double> S2[dim][dim];
 
   if (n_dependent_stiffness == true)
     {
@@ -252,8 +249,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -280,10 +277,8 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
   scalarvalueType c_beta =
     ((A2 * c + 0.5 * (A1 - B1) * (1.0 - h1V)) / (A2 * h1V + B2 * (1.0 - h1V)));
 
-  scalarvalueType faV   = (A2 * c_alpha * c_alpha + A1 * c_alpha + A0);
   scalarvalueType facV  = (2.0 * A2 * c_alpha + A1);
   scalarvalueType faccV = (constV(2.0) * A2);
-  scalarvalueType fbV   = (B2 * c_beta * c_beta + B1 * c_beta + B0);
   scalarvalueType fbcV  = (2.0 * B2 * c_beta + B1);
   scalarvalueType fbccV = (constV(2.0) * B2);
 
@@ -306,8 +301,7 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 
   // Calculate the stress-free transformation strain and its derivatives at the
   // quadrature point
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts1n,
-    sfts1cn;
+  Tensor<2, dim, VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts1n, sfts1cn;
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -324,7 +318,7 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
     }
 
   // compute E2=(E-E0)
-  dealii::VectorizedArray<double> E2[dim][dim], S[dim][dim];
+  VectorizedArray<double> E2[dim][dim], S[dim][dim];
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -337,7 +331,7 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
   // compute stress
   // S=C*(E-E0)
   //  Compute stress tensor (which is equal to the residual, Rux)
-  dealii::VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
+  VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
 
   if (n_dependent_stiffness == true)
     {
@@ -405,8 +399,8 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -419,14 +413,14 @@ customPDE<dim, degree>::equationLHS(
 
   // Take advantage of E being simply 0.5*(ux + transpose(ux)) and use the
   // dealii "symmetrize" function
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> E;
+  Tensor<2, dim, VectorizedArray<double>> E;
   E = symmetrize(variable_list.get_change_in_vector_gradient(3));
 
   // Compute stress tensor (which is equal to the residual, Rux)
   if (n_dependent_stiffness == true)
     {
       scalarvalueType h1V = (3.0 * n1 * n1 - 2.0 * n1 * n1 * n1);
-      dealii::Tensor<2, CIJ_tensor_size, dealii::VectorizedArray<double>> CIJ_combined;
+      Tensor<2, CIJ_tensor_size, VectorizedArray<double>> CIJ_combined;
       CIJ_combined = CIJ_Mg * (constV(1.0) - h1V);
       CIJ_combined += CIJ_Beta * (h1V);
 

--- a/applications/MgNd_precipitate_single_Bppp/postprocess.cc
+++ b/applications/MgNd_precipitate_single_Bppp/postprocess.cc
@@ -47,17 +47,17 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
   /// The concentration and its derivatives (names here should match those in
   /// the macros above)
   scalarvalueType c = variable_list.get_scalar_value(0);
-
-  scalargradType mux = variable_list.get_scalar_gradient(1);
 
   // The first order parameter and its derivatives (names here should match
   // those in the macros above)
@@ -75,8 +75,7 @@ customPDE<dim, degree>::postProcessedFields(
   scalarvalueType hn1V = (6.0 * n1 - 6.0 * n1 * n1);
 
   // This double-well function can be used to tune the interfacial energy
-  scalarvalueType fbarrierV  = (n1 * n1 - 2.0 * n1 * n1 * n1 + n1 * n1 * n1 * n1);
-  scalarvalueType fbarriernV = (2.0 * n1 - 6.0 * n1 * n1 + 4.0 * n1 * n1 * n1);
+  scalarvalueType fbarrierV = (n1 * n1 - 2.0 * n1 * n1 * n1 + n1 * n1 * n1 * n1);
 
   // Calculate c_alpha and c_beta from c
   scalarvalueType c_alpha =
@@ -120,8 +119,7 @@ customPDE<dim, degree>::postProcessedFields(
 
   // Calculate the stress-free transformation strain and its derivatives at the
   // quadrature point
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts1n,
-    sfts1cn;
+  Tensor<2, dim, VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts1n, sfts1cn;
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -138,7 +136,7 @@ customPDE<dim, degree>::postProcessedFields(
     }
 
   // compute E2=(E-E0)
-  dealii::VectorizedArray<double> E2[dim][dim], S[dim][dim];
+  VectorizedArray<double> E2[dim][dim], S[dim][dim];
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -150,8 +148,7 @@ customPDE<dim, degree>::postProcessedFields(
 
   // compute stress
   // S=C*(E-E0)
-  dealii::VectorizedArray<double> CIJ_combined[2 * dim - 1 + dim / 3]
-                                              [2 * dim - 1 + dim / 3];
+  VectorizedArray<double> CIJ_combined[2 * dim - 1 + dim / 3][2 * dim - 1 + dim / 3];
 
   if (n_dependent_stiffness == true)
     {
@@ -203,7 +200,7 @@ customPDE<dim, degree>::postProcessedFields(
     }
 
   // The Von Mises Stress
-  dealii::VectorizedArray<double> vm_stress;
+  VectorizedArray<double> vm_stress;
   if (dim == 3)
     {
       vm_stress = (S[0][0] - S[1][1]) * (S[0][0] - S[1][1]) +
@@ -221,13 +218,11 @@ customPDE<dim, degree>::postProcessedFields(
       vm_stress = std::sqrt(vm_stress);
     }
 
-  scalarvalueType dn_dt_chem, dn_dt_el;
-
   // Compute one of the stress terms in the order parameter chemical potential,
   // nDependentMisfitACp = -C*(E-E0)*(E0_n)
-  dealii::VectorizedArray<double> nDependentMisfitAC1    = constV(0.0);
-  dealii::VectorizedArray<double> nDependentMisfitAC1_t1 = constV(0.0);
-  dealii::VectorizedArray<double> nDependentMisfitAC1_t2 = constV(0.0);
+  VectorizedArray<double> nDependentMisfitAC1    = constV(0.0);
+  VectorizedArray<double> nDependentMisfitAC1_t1 = constV(0.0);
+  VectorizedArray<double> nDependentMisfitAC1_t2 = constV(0.0);
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -241,8 +236,8 @@ customPDE<dim, degree>::postProcessedFields(
 
   // Compute the other stress term in the order parameter chemical potential,
   // heterMechACp = 0.5*Hn*(C_beta-C_alpha)*(E-E0)*(E-E0)
-  dealii::VectorizedArray<double> heterMechAC1 = constV(0.0);
-  dealii::VectorizedArray<double> S2[dim][dim];
+  VectorizedArray<double> heterMechAC1 = constV(0.0);
+  VectorizedArray<double> S2[dim][dim];
 
   if (n_dependent_stiffness == true)
     {

--- a/applications/allenCahn/ICs_and_BCs.cc
+++ b/applications/allenCahn/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -61,12 +61,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/allenCahn/customPDE.h
+++ b/applications/allenCahn/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.cc)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.cc)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.cc)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/allenCahn/equations.cc
+++ b/applications/allenCahn/equations.cc
@@ -41,9 +41,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -79,9 +78,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -102,7 +100,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/allenCahn/postprocess.cc
+++ b/applications/allenCahn/postprocess.cc
@@ -45,12 +45,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  [[maybe_unused]] const variableContainer<dim, degree, dealii::VectorizedArray<double>>
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
     &variable_list,
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-    &pp_variable_list,
-  [[maybe_unused]] const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc)
-  const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/allenCahn_conserved/ICs_and_BCs.cc
+++ b/applications/allenCahn_conserved/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -67,12 +67,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/allenCahn_conserved/equations.cc
+++ b/applications/allenCahn_conserved/equations.cc
@@ -48,8 +48,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -87,8 +87,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // The order parameter and its derivatives
   scalarvalueType n  = variable_list.get_scalar_value(0);
@@ -127,6 +127,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/allenCahn_conserved/postprocess.cc
+++ b/applications/allenCahn_conserved/postprocess.cc
@@ -45,9 +45,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/alloySolidification/ICs_and_BCs.cc
+++ b/applications/alloySolidification/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -59,12 +59,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/alloySolidification/customPDE.h
+++ b/applications/alloySolidification/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/alloySolidification/equations.cc
+++ b/applications/alloySolidification/equations.cc
@@ -57,8 +57,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -155,8 +155,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -242,6 +242,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/alloySolidification/postprocess.cc
+++ b/applications/alloySolidification/postprocess.cc
@@ -38,9 +38,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/alloySolidification_uniform/ICs_and_BCs.cc
+++ b/applications/alloySolidification_uniform/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -60,12 +60,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/alloySolidification_uniform/customPDE.h
+++ b/applications/alloySolidification_uniform/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/alloySolidification_uniform/equations.cc
+++ b/applications/alloySolidification_uniform/equations.cc
@@ -57,8 +57,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -155,8 +155,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -237,6 +237,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/anisotropyFacet/ICs_and_BCs.cc
+++ b/applications/anisotropyFacet/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -56,12 +56,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/anisotropyFacet/anisotropy_facet.h
+++ b/applications/anisotropyFacet/anisotropy_facet.h
@@ -4,9 +4,9 @@
 template <int dim, int degree>
 void
 customPDE<dim, degree>::anisotropy(
-  const dealii::Tensor<1, dim, dealii::VectorizedArray<double>> &normal,
-  dealii::VectorizedArray<double>                               &gamma,
-  dealii::Tensor<1, dim, dealii::VectorizedArray<double>>       &dgammadnormal) const
+  const Tensor<1, dim, VectorizedArray<double>> &normal,
+  VectorizedArray<double>                       &gamma,
+  Tensor<1, dim, VectorizedArray<double>>       &dgammadnormal) const
 {
   // Orientations
   // Defining orientations in a static array greatly improves performance, but

--- a/applications/anisotropyFacet/customPDE.h
+++ b/applications/anisotropyFacet/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================
@@ -72,10 +80,9 @@ private:
   // ================================================================
 
   void
-  anisotropy(
-    const dealii::Tensor<1, dim, dealii::VectorizedArray<double>> &normal,
-    dealii::VectorizedArray<double>                               &gamma,
-    dealii::Tensor<1, dim, dealii::VectorizedArray<double>>       &dgammadnormal) const;
+  anisotropy(const Tensor<1, dim, VectorizedArray<double>> &normal,
+             VectorizedArray<double>                       &gamma,
+             Tensor<1, dim, VectorizedArray<double>>       &dgammadnormal) const;
 
   // ================================================================
   // Model constants specific to this subclass

--- a/applications/anisotropyFacet/equations.cc
+++ b/applications/anisotropyFacet/equations.cc
@@ -59,8 +59,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -142,8 +142,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -173,6 +173,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/anisotropyFacet/postprocess.cc
+++ b/applications/anisotropyFacet/postprocess.cc
@@ -38,9 +38,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/cahnHilliard/ICs_and_BCs.cc
+++ b/applications/cahnHilliard/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -68,12 +68,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/cahnHilliard/customPDE.h
+++ b/applications/cahnHilliard/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/cahnHilliard/equations.cc
+++ b/applications/cahnHilliard/equations.cc
@@ -49,8 +49,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
   scalarvalueType c   = variable_list.get_scalar_value(0);
@@ -81,8 +81,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -122,6 +122,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/cahnHilliard/postprocess.cc
+++ b/applications/cahnHilliard/postprocess.cc
@@ -38,9 +38,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/corrosion/ICs_and_BCs.cc
+++ b/applications/corrosion/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE FOR SCALAR FIELDS
@@ -62,12 +62,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/corrosion/customPDE.h
+++ b/applications/corrosion/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================
@@ -73,10 +81,10 @@ private:
 
   // Method that caps the value of the order parameter and the domain parameter
   void
-  capFields(dealii::VectorizedArray<double> &ncp,
-            dealii::VectorizedArray<double> &psicp,
-            dealii::VectorizedArray<double>  n,
-            dealii::VectorizedArray<double>  psi) const;
+  capFields(VectorizedArray<double> &ncp,
+            VectorizedArray<double> &psicp,
+            VectorizedArray<double>  n,
+            VectorizedArray<double>  psi) const;
 
   // ================================================================
   // Model constants specific to this subclass

--- a/applications/corrosion/equations.cc
+++ b/applications/corrosion/equations.cc
@@ -101,8 +101,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Parameters in the explicit equations can be set here  ---
 
@@ -228,8 +228,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -370,8 +370,8 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // The order parameter and its derivatives
   scalarvalueType n = variable_list.get_scalar_value(0);
@@ -475,10 +475,10 @@ customPDE<dim, degree>::equationLHS(
 // Method that caps the value of the order parameter and the domain parameter
 template <int dim, int degree>
 void
-customPDE<dim, degree>::capFields(dealii::VectorizedArray<double> &ncp,
-                                  dealii::VectorizedArray<double> &psicp,
-                                  dealii::VectorizedArray<double>  n,
-                                  dealii::VectorizedArray<double>  psi) const
+customPDE<dim, degree>::capFields(VectorizedArray<double> &ncp,
+                                  VectorizedArray<double> &psicp,
+                                  VectorizedArray<double>  n,
+                                  VectorizedArray<double>  psi) const
 {
   // Capping n to lower threshold bound and upper bound of 1
   for (unsigned j = 0; j < ncp.size(); j++)

--- a/applications/corrosion_microgalvanic/ICs_and_BCs.cc
+++ b/applications/corrosion_microgalvanic/ICs_and_BCs.cc
@@ -7,10 +7,11 @@ using namespace std;
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition(
+  [[maybe_unused]] const dealii::Point<dim> &p,
+  [[maybe_unused]] const unsigned int        index,
+  [[maybe_unused]] double                   &scalar_IC,
+  [[maybe_unused]] dealii::Vector<double>   &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE FOR SCALAR FIELDS
@@ -91,12 +92,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const dealii::Point<dim> &p,
+  [[maybe_unused]] const unsigned int        index,
+  [[maybe_unused]] const unsigned int        direction,
+  [[maybe_unused]] const double              time,
+  [[maybe_unused]] double                   &scalar_BC,
+  [[maybe_unused]] dealii::Vector<double>   &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/corrosion_microgalvanic/customPDE.h
+++ b/applications/corrosion_microgalvanic/customPDE.h
@@ -14,20 +14,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const dealii::Point<dim> &p,
+                      [[maybe_unused]] const unsigned int        index,
+                      [[maybe_unused]] double                   &scalar_IC,
+                      [[maybe_unused]] dealii::Vector<double>   &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet
   // boundary conditions (in ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const dealii::Point<dim> &p,
+                            [[maybe_unused]] const unsigned int        index,
+                            [[maybe_unused]] const unsigned int        direction,
+                            [[maybe_unused]] const double              time,
+                            [[maybe_unused]] double                   &scalar_BC,
+                            [[maybe_unused]] dealii::Vector<double> &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -39,38 +39,47 @@ private:
 
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
+                                                                        &variable_list,
+    [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc)
+    const override;
 
   // Function to set the RHS of the governing equations
   // for all other equations (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
+                                                                        &variable_list,
+    [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc)
+    const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
+                                                                        &variable_list,
+    [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc)
+    const override;
 
   // Function to set postprocessing expressions (in postprocess.h)
 
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, dealii::VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
+      &pp_variable_list,
+    [[maybe_unused]] const dealii::Point<dim, dealii::VectorizedArray<double>>
+      q_point_loc) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 // Not useful for this application
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/corrosion_microgalvanic/equations.cc
+++ b/applications/corrosion_microgalvanic/equations.cc
@@ -122,8 +122,9 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
+                                                                      &variable_list,
+  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
 {
   // --- Parameters in the explicit equations can be set here  ---
 
@@ -182,13 +183,11 @@ customPDE<dim, degree>::explicitEquationRHS(
   // --- Calculation of irxn  ---
 
   // Overpotentials for the anodic and cathodic phases
-  scalarvalueType etaAnodic   = VsV - EcorrAnodic - Phi;
-  scalarvalueType etaCathodic = VsV - EcorrCathodic - Phi;
+  scalarvalueType etaAnodic = VsV - EcorrAnodic - Phi;
 
   // Calculation of anodic/cathodic current density
-  scalarvalueType itafel    = i0Anodic * exp(etaAnodic / AAnodic);
-  scalarvalueType iAnodic   = itafel / (constV(1.0) + (itafel / iMax));
-  scalarvalueType iCathodic = -i0Cathodic * exp(etaCathodic / ACathodic);
+  scalarvalueType itafel  = i0Anodic * exp(etaAnodic / AAnodic);
+  scalarvalueType iAnodic = itafel / (constV(1.0) + (itafel / iMax));
 
   // Time for initial equilibration of all the interfaces present in the
   // domain
@@ -256,8 +255,9 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
+                                                                      &variable_list,
+  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -396,8 +396,9 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
+                                                                      &variable_list,
+  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
 {
   // The order parameter of the anodic phase
   scalarvalueType nAnodic = variable_list.get_scalar_value(0);
@@ -450,7 +451,6 @@ customPDE<dim, degree>::equationLHS(
 
   // Calculation of anodic/cathodic current density
   scalarvalueType itafel    = i0Anodic * exp(etaAnodic / AAnodic);
-  scalarvalueType iAnodic   = itafel / (constV(1.0) + (itafel / iMax));
   scalarvalueType iCathodic = -i0Cathodic * exp(etaCathodic / ACathodic);
 
   // The interpolation factor for the cathodic phase

--- a/applications/coupledCahnHilliardAllenCahn/ICs_and_BCs.cc
+++ b/applications/coupledCahnHilliardAllenCahn/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -70,12 +70,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/coupledCahnHilliardAllenCahn/customPDE.h
+++ b/applications/coupledCahnHilliardAllenCahn/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================
@@ -79,8 +87,8 @@ private:
   double Mn = userInputs.get_model_constant_double("Mn");
   double Kn = userInputs.get_model_constant_double("Kn");
 
-  dealii::Tensor<1, dim> center1 = userInputs.get_model_constant_rank_1_tensor("center1");
-  dealii::Tensor<1, dim> center2 = userInputs.get_model_constant_rank_1_tensor("center2");
+  Tensor<1, dim> center1 = userInputs.get_model_constant_rank_1_tensor("center1");
+  Tensor<1, dim> center2 = userInputs.get_model_constant_rank_1_tensor("center2");
 
   double radius1 = userInputs.get_model_constant_double("radius1");
   double radius2 = userInputs.get_model_constant_double("radius2");

--- a/applications/coupledCahnHilliardAllenCahn/equations.cc
+++ b/applications/coupledCahnHilliardAllenCahn/equations.cc
@@ -49,8 +49,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -111,8 +111,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -133,6 +133,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/coupledCahnHilliardAllenCahn/postprocess.cc
+++ b/applications/coupledCahnHilliardAllenCahn/postprocess.cc
@@ -45,9 +45,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/dendriticSolidification/ICs_and_BCs.cc
+++ b/applications/dendriticSolidification/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -59,12 +59,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/dendriticSolidification/customPDE.h
+++ b/applications/dendriticSolidification/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/dendriticSolidification/equations.cc
+++ b/applications/dendriticSolidification/equations.cc
@@ -57,8 +57,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -119,8 +119,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -154,7 +154,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
   scalarvalueType W_theta =
     constV(-W0) *
     (constV(epsilonM) * constV(mult) * std::sin(constV(mult) * (theta - constV(theta0))));
-  scalarvalueType tau = W / constV(W0);
 
   // The anisotropy term that enters in to the  equation for mu
   scalargradType aniso;
@@ -189,6 +188,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/eshelbyInclusion/ICs_and_BCs.cc
+++ b/applications/eshelbyInclusion/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -30,12 +30,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/eshelbyInclusion/customPDE.h
+++ b/applications/eshelbyInclusion/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================
@@ -75,9 +83,8 @@ private:
   // Model constants specific to this subclass
   // ================================================================
 
-  const static unsigned int          CIJ_tensor_size = 2 * dim - 1 + dim / 3;
-  dealii::Tensor<2, CIJ_tensor_size> CIJ =
-    userInputs.get_model_constant_elasticity_tensor("CIJ");
+  const static unsigned int  CIJ_tensor_size = 2 * dim - 1 + dim / 3;
+  Tensor<2, CIJ_tensor_size> CIJ = userInputs.get_model_constant_elasticity_tensor("CIJ");
 
   // ================================================================
 };

--- a/applications/eshelbyInclusion/equations.cc
+++ b/applications/eshelbyInclusion/equations.cc
@@ -43,8 +43,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -63,8 +63,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -106,7 +106,7 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
     }
 
   // compute strain tensor
-  dealii::VectorizedArray<double> E[dim][dim], S[dim][dim];
+  VectorizedArray<double> E[dim][dim], S[dim][dim];
   for (unsigned int i = 0; i < dim; i++)
     {
       for (unsigned int j = 0; j < dim; j++)
@@ -150,8 +150,8 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -163,7 +163,7 @@ customPDE<dim, degree>::equationLHS(
   vectorgradType eqx_Du;
 
   // compute strain tensor
-  dealii::VectorizedArray<double> E[dim][dim], S[dim][dim];
+  VectorizedArray<double> E[dim][dim], S[dim][dim];
   for (unsigned int i = 0; i < dim; i++)
     {
       for (unsigned int j = 0; j < dim; j++)

--- a/applications/fickianDiffusion/ICs_and_BCs.cc
+++ b/applications/fickianDiffusion/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -27,12 +27,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/fickianDiffusion/customPDE.h
+++ b/applications/fickianDiffusion/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/fickianDiffusion/equations.cc
+++ b/applications/fickianDiffusion/equations.cc
@@ -41,8 +41,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -104,8 +104,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -126,6 +126,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/grainGrowth/ICs_and_BCs.cc
+++ b/applications/grainGrowth/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -22,71 +22,71 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
   if (index < 5)
     {
-      std::vector<dealii::Point<dim>> center;
+      std::vector<Point<dim>> center;
 
       // The big grains
       {
-        dealii::Point<dim> p(0.2, 0.15);
+        Point<dim> p(0.2, 0.15);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.25, 0.7);
+        Point<dim> p(0.25, 0.7);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.5, 0.5);
+        Point<dim> p(0.5, 0.5);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.6, 0.85);
+        Point<dim> p(0.6, 0.85);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.85, 0.35);
+        Point<dim> p(0.85, 0.35);
         center.push_back(p);
       }
 
       // The medium grains
       {
-        dealii::Point<dim> p(0.08, 0.92);
+        Point<dim> p(0.08, 0.92);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.75, 0.6);
+        Point<dim> p(0.75, 0.6);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.75, 0.1);
+        Point<dim> p(0.75, 0.1);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.2, 0.45);
+        Point<dim> p(0.2, 0.45);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.85, 0.85);
+        Point<dim> p(0.85, 0.85);
         center.push_back(p);
       }
 
       // The small grains
       {
-        dealii::Point<dim> p(0.55, 0.05);
+        Point<dim> p(0.55, 0.05);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.1, 0.35);
+        Point<dim> p(0.1, 0.35);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.95, 0.65);
+        Point<dim> p(0.95, 0.65);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.9, 0.15);
+        Point<dim> p(0.9, 0.15);
         center.push_back(p);
       }
       {
-        dealii::Point<dim> p(0.45, 0.25);
+        Point<dim> p(0.45, 0.25);
         center.push_back(p);
       }
 
@@ -157,12 +157,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/grainGrowth/customPDE.h
+++ b/applications/grainGrowth/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/grainGrowth/equations.cc
+++ b/applications/grainGrowth/equations.cc
@@ -48,15 +48,14 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
-  dealii::VectorizedArray<double> fnV = constV(0.0);
-  scalarvalueType                 ni, nj;
-  scalargradType                  nix;
+  VectorizedArray<double> fnV = constV(0.0);
+  scalarvalueType         ni, nj;
+  scalargradType          nix;
 
   // In this application, create temporary variables for the residual terms. We
   // cannot call 'set_scalar_value_residual_term' and
@@ -112,9 +111,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -135,7 +133,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/grainGrowth/postprocess.cc
+++ b/applications/grainGrowth/postprocess.cc
@@ -45,12 +45,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  [[maybe_unused]] const variableContainer<dim, degree, dealii::VectorizedArray<double>>
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
     &variable_list,
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-    &pp_variable_list,
-  [[maybe_unused]] const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc)
-  const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -82,7 +81,7 @@ customPDE<dim, degree>::postProcessedFields(
           if (this->simplified_grain_representations[g].getOrderParameterId() ==
               max_op_nonvec)
             {
-              dealii::Point<dim> q_point_loc_nonvec;
+              Point<dim> q_point_loc_nonvec;
               for (unsigned int d = 0; d < dim; d++)
                 {
                   q_point_loc_nonvec(d) = q_point_loc(d)[v];

--- a/applications/grainGrowth_dream3d/ICs_and_BCs.cc
+++ b/applications/grainGrowth_dream3d/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -25,12 +25,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/grainGrowth_dream3d/customPDE.h
+++ b/applications/grainGrowth_dream3d/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/grainGrowth_dream3d/equations.cc
+++ b/applications/grainGrowth_dream3d/equations.cc
@@ -59,14 +59,14 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
-  dealii::VectorizedArray<double> fnV = constV(0.0);
-  scalarvalueType                 ni, nj;
-  scalargradType                  nix;
+  VectorizedArray<double> fnV = constV(0.0);
+  scalarvalueType         ni, nj;
+  scalargradType          nix;
 
   // In this application, create temporary variables for the residual terms. We
   // cannot call 'set_scalar_value_residual_term' and
@@ -122,8 +122,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -144,6 +144,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/grainGrowth_dream3d/postprocess.cc
+++ b/applications/grainGrowth_dream3d/postprocess.cc
@@ -57,9 +57,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -91,7 +93,7 @@ customPDE<dim, degree>::postProcessedFields(
           if (this->simplified_grain_representations[g].getOrderParameterId() ==
               max_op_nonvec)
             {
-              dealii::Point<dim> q_point_loc_nonvec;
+              Point<dim> q_point_loc_nonvec;
               for (unsigned int d = 0; d < dim; d++)
                 {
                   q_point_loc_nonvec(d) = q_point_loc(d)[v];

--- a/applications/mechanics/ICs_and_BCs.cc
+++ b/applications/mechanics/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -29,12 +29,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/mechanics/customPDE.h
+++ b/applications/mechanics/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================
@@ -75,9 +83,8 @@ private:
   // Model constants specific to this subclass
   // ================================================================
 
-  const static unsigned int          CIJ_tensor_size = 2 * dim - 1 + dim / 3;
-  dealii::Tensor<2, CIJ_tensor_size> CIJ =
-    userInputs.get_model_constant_elasticity_tensor("CIJ");
+  const static unsigned int  CIJ_tensor_size = 2 * dim - 1 + dim / 3;
+  Tensor<2, CIJ_tensor_size> CIJ = userInputs.get_model_constant_elasticity_tensor("CIJ");
 
   // ================================================================
 };

--- a/applications/mechanics/equations.cc
+++ b/applications/mechanics/equations.cc
@@ -34,8 +34,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -54,8 +54,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -67,7 +67,7 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
   vectorgradType eqx_u;
 
   // compute strain tensor
-  dealii::VectorizedArray<double> E[dim][dim], S[dim][dim];
+  VectorizedArray<double> E[dim][dim], S[dim][dim];
   for (unsigned int i = 0; i < dim; i++)
     {
       for (unsigned int j = 0; j < dim; j++)
@@ -111,8 +111,8 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -124,7 +124,7 @@ customPDE<dim, degree>::equationLHS(
   vectorgradType eqx_Du;
 
   // compute strain tensor
-  dealii::VectorizedArray<double> E[dim][dim], S[dim][dim];
+  VectorizedArray<double> E[dim][dim], S[dim][dim];
   for (unsigned int i = 0; i < dim; i++)
     {
       for (unsigned int j = 0; j < dim; j++)

--- a/applications/nucleationModel/ICs_and_BCs.cc
+++ b/applications/nucleationModel/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -15,11 +15,6 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
   // Enter the function describing conditions for the fields at point "p".
   // Use "if" statements to set the initial condition for each variable
   // according to its variable index
-
-  double dx = userInputs.domain_size[0] / ((double) userInputs.subdivisions[0]) /
-              std::pow(2.0, userInputs.refine_factor);
-
-  double r = 0.0;
 
   // Initial condition for the concentration field
   if (index == 0)
@@ -41,12 +36,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/nucleationModel/customPDE.h
+++ b/applications/nucleationModel/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -10,20 +12,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -34,38 +36,44 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Virtual method in MatrixFreePDE that we override if we need nucleation
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV,
-                           dealii::Point<dim>     p,
-                           unsigned int           variable_index) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV,
+                           [[maybe_unused]] Point<dim>             p,
+                           [[maybe_unused]] unsigned int variable_index) const override;
 #endif
 
   // ================================================================
@@ -75,9 +83,9 @@ private:
   // Method to place the nucleus and calculate the mobility modifier in
   // residualRHS
   void
-  seedNucleus(const dealii::Point<dim, dealii::VectorizedArray<double>> &q_point_loc,
-              dealii::VectorizedArray<double>                           &source_term,
-              dealii::VectorizedArray<double>                           &gamma) const;
+  seedNucleus(const Point<dim, VectorizedArray<double>> &q_point_loc,
+              VectorizedArray<double>                   &source_term,
+              VectorizedArray<double>                   &gamma) const;
 
   // ================================================================
   // Model constants specific to this subclass

--- a/applications/nucleationModel/equations.cc
+++ b/applications/nucleationModel/equations.cc
@@ -55,8 +55,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -81,22 +81,18 @@ customPDE<dim, degree>::explicitEquationRHS(
                            (A2 * hV + B2 * (1.0 - hV));
 
   // Free energy for each phase and their first and second derivatives
-  scalarvalueType faV   = A0 + A2 * (c_alpha - calmin) * (c_alpha - calmin);
-  scalarvalueType facV  = 2.0 * A2 * (c_alpha - calmin);
-  scalarvalueType faccV = constV(2.0) * A2;
-  scalarvalueType fbV   = B0 + B2 * (c_beta - cbtmin) * (c_beta - cbtmin);
-  scalarvalueType fbcV  = 2.0 * B2 * (c_beta - cbtmin);
-  scalarvalueType fbccV = constV(2.0) * B2;
+  scalarvalueType faV  = A0 + A2 * (c_alpha - calmin) * (c_alpha - calmin);
+  scalarvalueType fbV  = B0 + B2 * (c_beta - cbtmin) * (c_beta - cbtmin);
+  scalarvalueType fbcV = 2.0 * B2 * (c_beta - cbtmin);
 
   // Double-Well function (can be used to tune the interfacial energy)
-  scalarvalueType fbarrierV  = n * n - 2.0 * n * n * n + n * n * n * n;
   scalarvalueType fbarriernV = 2.0 * n - 6.0 * n * n + 4.0 * n * n * n;
 
   // -------------------------------------------------
   // Nucleation expressions
   // -------------------------------------------------
-  dealii::VectorizedArray<double> source_term = constV(0.0);
-  dealii::VectorizedArray<double> gamma       = constV(1.0);
+  VectorizedArray<double> source_term = constV(0.0);
+  VectorizedArray<double> gamma       = constV(1.0);
   seedNucleus(q_point_loc, source_term, gamma);
   // -------------------------------------------------
 
@@ -129,9 +125,9 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::seedNucleus(
-  const dealii::Point<dim, dealii::VectorizedArray<double>> &q_point_loc,
-  dealii::VectorizedArray<double>                           &source_term,
-  dealii::VectorizedArray<double>                           &gamma) const
+  const Point<dim, VectorizedArray<double>> &q_point_loc,
+  VectorizedArray<double>                   &source_term,
+  VectorizedArray<double>                   &gamma) const
 {
   for (const auto &thisNucleus : this->nuclei)
     {
@@ -139,12 +135,11 @@ customPDE<dim, degree>::seedNucleus(
         {
           // Calculate the weighted distance function to the order parameter
           // freeze boundary (weighted_dist = 1.0 on that boundary)
-          dealii::VectorizedArray<double> weighted_dist =
-            this->weightedDistanceFromNucleusCenter(
-              thisNucleus.center,
-              userInputs.get_nucleus_freeze_semiaxes(thisNucleus.orderParameterIndex),
-              q_point_loc,
-              thisNucleus.orderParameterIndex);
+          VectorizedArray<double> weighted_dist = this->weightedDistanceFromNucleusCenter(
+            thisNucleus.center,
+            userInputs.get_nucleus_freeze_semiaxes(thisNucleus.orderParameterIndex),
+            q_point_loc,
+            thisNucleus.orderParameterIndex);
 
           for (unsigned i = 0; i < gamma.size(); i++)
             {
@@ -159,7 +154,7 @@ customPDE<dim, degree>::seedNucleus(
                       // Find the weighted distance to the outer edge of the
                       // nucleus and use it to calculate the order parameter
                       // source term
-                      dealii::Point<dim, double> q_point_loc_element;
+                      Point<dim, double> q_point_loc_element;
                       for (unsigned int j = 0; j < dim; j++)
                         {
                           q_point_loc_element(j) = q_point_loc(j)[i];
@@ -203,8 +198,8 @@ customPDE<dim, degree>::seedNucleus(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -225,6 +220,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/nucleationModel/nucleation.cc
+++ b/applications/nucleationModel/nucleation.cc
@@ -7,10 +7,11 @@
 // =================================================================================
 template <int dim, int degree>
 double
-customPDE<dim, degree>::getNucleationProbability(variableValueContainer variable_value,
-                                                 double                 dV,
-                                                 dealii::Point<dim>     p,
-                                                 unsigned int variable_index) const
+customPDE<dim, degree>::getNucleationProbability(
+  [[maybe_unused]] variableValueContainer variable_value,
+  [[maybe_unused]] double                 dV,
+  [[maybe_unused]] dealii::Point<dim>     p,
+  [[maybe_unused]] unsigned int           variable_index) const
 {
   // Supersaturation factor
   double ssf;

--- a/applications/nucleationModel_preferential/ICs_and_BCs.cc
+++ b/applications/nucleationModel_preferential/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -15,11 +15,6 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
   // Enter the function describing conditions for the fields at point "p".
   // Use "if" statements to set the initial condition for each variable
   // according to its variable index
-
-  double dx = userInputs.domain_size[0] / ((double) userInputs.subdivisions[0]) /
-              std::pow(2.0, userInputs.refine_factor);
-
-  double r = 0.0;
 
   // Initial condition for the concentration field
   if (index == 0)
@@ -41,12 +36,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/nucleationModel_preferential/customPDE.h
+++ b/applications/nucleationModel_preferential/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -10,20 +12,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -34,38 +36,44 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Virtual method in MatrixFreePDE that we override if we need nucleation
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV,
-                           dealii::Point<dim>     p,
-                           unsigned int           variable_index) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV,
+                           [[maybe_unused]] Point<dim>             p,
+                           [[maybe_unused]] unsigned int variable_index) const override;
 #endif
 
   // ================================================================
@@ -75,9 +83,9 @@ private:
   // Method to place the nucleus and calculate the mobility modifier in
   // residualRHS
   void
-  seedNucleus(const dealii::Point<dim, dealii::VectorizedArray<double>> &q_point_loc,
-              dealii::VectorizedArray<double>                           &source_term,
-              dealii::VectorizedArray<double>                           &gamma) const;
+  seedNucleus(const Point<dim, VectorizedArray<double>> &q_point_loc,
+              VectorizedArray<double>                   &source_term,
+              VectorizedArray<double>                   &gamma) const;
 
   // Method to refine the mesh
   void
@@ -129,8 +137,8 @@ customPDE<dim, degree>::adaptive_refinement_criterion()
     *(this->FESet[userInputs.refinement_criteria[0].variable_index]),
     quadrature,
     update_values | update_quadrature_points);
-  const unsigned int              num_quad_points = quadrature.size();
-  std::vector<dealii::Point<dim>> q_point_list(num_quad_points);
+  const unsigned int      num_quad_points = quadrature.size();
+  std::vector<Point<dim>> q_point_list(num_quad_points);
 
   std::vector<double> errorOut(num_quad_points);
 

--- a/applications/nucleationModel_preferential/equations.cc
+++ b/applications/nucleationModel_preferential/equations.cc
@@ -55,8 +55,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -81,22 +81,18 @@ customPDE<dim, degree>::explicitEquationRHS(
                            (A2 * hV + B2 * (1.0 - hV));
 
   // Free energy for each phase and their first and second derivatives
-  scalarvalueType faV   = A0 + A2 * (c_alpha - calmin) * (c_alpha - calmin);
-  scalarvalueType facV  = 2.0 * A2 * (c_alpha - calmin);
-  scalarvalueType faccV = constV(2.0) * A2;
-  scalarvalueType fbV   = B0 + B2 * (c_beta - cbtmin) * (c_beta - cbtmin);
-  scalarvalueType fbcV  = 2.0 * B2 * (c_beta - cbtmin);
-  scalarvalueType fbccV = constV(2.0 * B2);
+  scalarvalueType faV  = A0 + A2 * (c_alpha - calmin) * (c_alpha - calmin);
+  scalarvalueType fbV  = B0 + B2 * (c_beta - cbtmin) * (c_beta - cbtmin);
+  scalarvalueType fbcV = 2.0 * B2 * (c_beta - cbtmin);
 
   // Double-Well function (can be used to tune the interfacial energy)
-  scalarvalueType fbarrierV  = n * n - 2.0 * n * n * n + n * n * n * n;
   scalarvalueType fbarriernV = 2.0 * n - 6.0 * n * n + 4.0 * n * n * n;
 
   // -------------------------------------------------
   // Nucleation expressions
   // -------------------------------------------------
-  dealii::VectorizedArray<double> source_term = constV(0.0);
-  dealii::VectorizedArray<double> gamma       = constV(1.0);
+  VectorizedArray<double> source_term = constV(0.0);
+  VectorizedArray<double> gamma       = constV(1.0);
   seedNucleus(q_point_loc, source_term, gamma);
   // -------------------------------------------------
 
@@ -129,9 +125,9 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::seedNucleus(
-  const dealii::Point<dim, dealii::VectorizedArray<double>> &q_point_loc,
-  dealii::VectorizedArray<double>                           &source_term,
-  dealii::VectorizedArray<double>                           &gamma) const
+  const Point<dim, VectorizedArray<double>> &q_point_loc,
+  VectorizedArray<double>                   &source_term,
+  VectorizedArray<double>                   &gamma) const
 {
   // Loop through all of the seeded nuclei
   for (const auto &thisNucleus : this->nuclei)
@@ -140,12 +136,11 @@ customPDE<dim, degree>::seedNucleus(
         {
           // Calculate the weighted distance function to the order parameter
           // freeze boundary (weighted_dist = 1.0 on that boundary)
-          dealii::VectorizedArray<double> weighted_dist =
-            this->weightedDistanceFromNucleusCenter(
-              thisNucleus.center,
-              userInputs.get_nucleus_freeze_semiaxes(thisNucleus.orderParameterIndex),
-              q_point_loc,
-              thisNucleus.orderParameterIndex);
+          VectorizedArray<double> weighted_dist = this->weightedDistanceFromNucleusCenter(
+            thisNucleus.center,
+            userInputs.get_nucleus_freeze_semiaxes(thisNucleus.orderParameterIndex),
+            q_point_loc,
+            thisNucleus.orderParameterIndex);
 
           for (unsigned i = 0; i < gamma.size(); i++)
             {
@@ -160,7 +155,7 @@ customPDE<dim, degree>::seedNucleus(
                       // Find the weighted distance to the outer edge of the
                       // nucleus and use it to calculate the order parameter
                       // source term (r = 1.0 on that boundary)
-                      dealii::Point<dim, double> q_point_loc_element;
+                      Point<dim, double> q_point_loc_element;
                       for (unsigned int j = 0; j < dim; j++)
                         {
                           q_point_loc_element(j) = q_point_loc(j)[i];
@@ -204,8 +199,8 @@ customPDE<dim, degree>::seedNucleus(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}
 
 // =============================================================================================
@@ -226,6 +221,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/nucleationModel_preferential/nucleation.cc
+++ b/applications/nucleationModel_preferential/nucleation.cc
@@ -7,10 +7,11 @@
 // =================================================================================
 template <int dim, int degree>
 double
-customPDE<dim, degree>::getNucleationProbability(variableValueContainer variable_value,
-                                                 double                 dV,
-                                                 dealii::Point<dim>     p,
-                                                 unsigned int variable_index) const
+customPDE<dim, degree>::getNucleationProbability(
+  [[maybe_unused]] variableValueContainer variable_value,
+  [[maybe_unused]] double                 dV,
+  [[maybe_unused]] Point<dim>             p,
+  [[maybe_unused]] unsigned int           variable_index) const
 {
   // Supersaturation factor
   double ssf;

--- a/applications/precipitateEvolution/ICs_and_BCs.cc
+++ b/applications/precipitateEvolution/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -70,12 +70,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/precipitateEvolution/customPDE.h
+++ b/applications/precipitateEvolution/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -9,20 +11,20 @@ public:
     , userInputs(_userInputs) {};
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -33,36 +35,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================
@@ -73,40 +81,37 @@ private:
   // Model constants specific to this subclass
   // ================================================================
 
-  double                 McV  = userInputs.get_model_constant_double("McV");
-  double                 Mn1V = userInputs.get_model_constant_double("Mn1V");
-  double                 Mn2V = userInputs.get_model_constant_double("Mn2V");
-  double                 Mn3V = userInputs.get_model_constant_double("Mn3V");
-  dealii::Tensor<2, dim> Kn1  = userInputs.get_model_constant_rank_2_tensor("Kn1");
-  dealii::Tensor<2, dim> Kn2  = userInputs.get_model_constant_rank_2_tensor("Kn2");
-  dealii::Tensor<2, dim> Kn3  = userInputs.get_model_constant_rank_2_tensor("Kn3");
-  bool                   n_dependent_stiffness =
+  double         McV  = userInputs.get_model_constant_double("McV");
+  double         Mn1V = userInputs.get_model_constant_double("Mn1V");
+  double         Mn2V = userInputs.get_model_constant_double("Mn2V");
+  double         Mn3V = userInputs.get_model_constant_double("Mn3V");
+  Tensor<2, dim> Kn1  = userInputs.get_model_constant_rank_2_tensor("Kn1");
+  Tensor<2, dim> Kn2  = userInputs.get_model_constant_rank_2_tensor("Kn2");
+  Tensor<2, dim> Kn3  = userInputs.get_model_constant_rank_2_tensor("Kn3");
+  bool           n_dependent_stiffness =
     userInputs.get_model_constant_bool("n_dependent_stiffness");
-  dealii::Tensor<2, dim> sfts_linear1 =
+  Tensor<2, dim> sfts_linear1 =
     userInputs.get_model_constant_rank_2_tensor("sfts_linear1");
-  dealii::Tensor<2, dim> sfts_const1 =
-    userInputs.get_model_constant_rank_2_tensor("sfts_const1");
-  dealii::Tensor<2, dim> sfts_linear2 =
+  Tensor<2, dim> sfts_const1 = userInputs.get_model_constant_rank_2_tensor("sfts_const1");
+  Tensor<2, dim> sfts_linear2 =
     userInputs.get_model_constant_rank_2_tensor("sfts_linear2");
-  dealii::Tensor<2, dim> sfts_const2 =
-    userInputs.get_model_constant_rank_2_tensor("sfts_const2");
-  dealii::Tensor<2, dim> sfts_linear3 =
+  Tensor<2, dim> sfts_const2 = userInputs.get_model_constant_rank_2_tensor("sfts_const2");
+  Tensor<2, dim> sfts_linear3 =
     userInputs.get_model_constant_rank_2_tensor("sfts_linear3");
-  dealii::Tensor<2, dim> sfts_const3 =
-    userInputs.get_model_constant_rank_2_tensor("sfts_const3");
-  double A4 = userInputs.get_model_constant_double("A4");
-  double A3 = userInputs.get_model_constant_double("A3");
-  double A2 = userInputs.get_model_constant_double("A2");
-  double A1 = userInputs.get_model_constant_double("A1");
-  double A0 = userInputs.get_model_constant_double("A0");
-  double B2 = userInputs.get_model_constant_double("B2");
-  double B1 = userInputs.get_model_constant_double("B1");
-  double B0 = userInputs.get_model_constant_double("B0");
+  Tensor<2, dim> sfts_const3 = userInputs.get_model_constant_rank_2_tensor("sfts_const3");
+  double         A4          = userInputs.get_model_constant_double("A4");
+  double         A3          = userInputs.get_model_constant_double("A3");
+  double         A2          = userInputs.get_model_constant_double("A2");
+  double         A1          = userInputs.get_model_constant_double("A1");
+  double         A0          = userInputs.get_model_constant_double("A0");
+  double         B2          = userInputs.get_model_constant_double("B2");
+  double         B1          = userInputs.get_model_constant_double("B1");
+  double         B0          = userInputs.get_model_constant_double("B0");
 
-  const static unsigned int          CIJ_tensor_size = 2 * dim - 1 + dim / 3;
-  dealii::Tensor<2, CIJ_tensor_size> CIJ_Mg =
+  const static unsigned int  CIJ_tensor_size = 2 * dim - 1 + dim / 3;
+  Tensor<2, CIJ_tensor_size> CIJ_Mg =
     userInputs.get_model_constant_elasticity_tensor("CIJ_Mg");
-  dealii::Tensor<2, CIJ_tensor_size> CIJ_Beta =
+  Tensor<2, CIJ_tensor_size> CIJ_Beta =
     userInputs.get_model_constant_elasticity_tensor("CIJ_Beta");
 
   // ================================================================

--- a/applications/precipitateEvolution/equations.cc
+++ b/applications/precipitateEvolution/equations.cc
@@ -77,9 +77,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -145,8 +144,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 
   // Calculate the stress-free transformation strain and its derivatives at the
   // quadrature point
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts2,
-    sfts2c, sfts2cc, sfts3, sfts3c, sfts3cc;
+  Tensor<2, dim, VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts2, sfts2c, sfts2cc,
+    sfts3, sfts3c, sfts3cc;
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -173,7 +172,7 @@ customPDE<dim, degree>::explicitEquationRHS(
     }
 
   // compute E2=(E-E0)
-  dealii::VectorizedArray<double> E2[dim][dim], S[dim][dim];
+  VectorizedArray<double> E2[dim][dim], S[dim][dim];
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -187,11 +186,11 @@ customPDE<dim, degree>::explicitEquationRHS(
   // compute stress
   // S=C*(E-E0)
   //  Compute stress tensor (which is equal to the residual, Rux)
-  dealii::VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
+  VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
 
   if (n_dependent_stiffness == true)
     {
-      dealii::VectorizedArray<double> sum_hV;
+      VectorizedArray<double> sum_hV;
       sum_hV = h1V + h2V + h3V;
       for (unsigned int i = 0; i < 2 * dim - 1 + dim / 3; i++)
         {
@@ -210,9 +209,9 @@ customPDE<dim, degree>::explicitEquationRHS(
 
   // Compute one of the stress terms in the order parameter chemical potential,
   // nDependentMisfitACp = C*(E-E0)*(E0_p*Hn)
-  dealii::VectorizedArray<double> nDependentMisfitAC1 = constV(0.0);
-  dealii::VectorizedArray<double> nDependentMisfitAC2 = constV(0.0);
-  dealii::VectorizedArray<double> nDependentMisfitAC3 = constV(0.0);
+  VectorizedArray<double> nDependentMisfitAC1 = constV(0.0);
+  VectorizedArray<double> nDependentMisfitAC2 = constV(0.0);
+  VectorizedArray<double> nDependentMisfitAC3 = constV(0.0);
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -230,10 +229,10 @@ customPDE<dim, degree>::explicitEquationRHS(
 
   // Compute the other stress term in the order parameter chemical potential,
   // heterMechACp = 0.5*Hn*(C_beta-C_alpha)*(E-E0)*(E-E0)
-  dealii::VectorizedArray<double> heterMechAC1 = constV(0.0);
-  dealii::VectorizedArray<double> heterMechAC2 = constV(0.0);
-  dealii::VectorizedArray<double> heterMechAC3 = constV(0.0);
-  dealii::VectorizedArray<double> S2[dim][dim];
+  VectorizedArray<double> heterMechAC1 = constV(0.0);
+  VectorizedArray<double> heterMechAC2 = constV(0.0);
+  VectorizedArray<double> heterMechAC3 = constV(0.0);
+  VectorizedArray<double> S2[dim][dim];
 
   if (n_dependent_stiffness == true)
     {
@@ -259,7 +258,7 @@ customPDE<dim, degree>::explicitEquationRHS(
 
   if (c_dependent_misfit == true)
     {
-      dealii::VectorizedArray<double> E3[dim][dim], S3[dim][dim];
+      VectorizedArray<double> E3[dim][dim], S3[dim][dim];
 
       for (unsigned int i = 0; i < dim; i++)
         {
@@ -374,9 +373,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -407,7 +405,7 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 
   // Calculate the stress-free transformation strain and its derivatives at the
   // quadrature point
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> sfts1, sfts2, sfts3;
+  Tensor<2, dim, VectorizedArray<double>> sfts1, sfts2, sfts3;
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -426,7 +424,7 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
     }
 
   // compute E2=(E-E0)
-  dealii::VectorizedArray<double> E2[dim][dim], S[dim][dim];
+  VectorizedArray<double> E2[dim][dim], S[dim][dim];
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -440,11 +438,11 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
   // compute stress
   // S=C*(E-E0)
   //  Compute stress tensor (which is equal to the residual, Rux)
-  dealii::VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
+  VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
 
   if (n_dependent_stiffness == true)
     {
-      dealii::VectorizedArray<double> sum_hV;
+      VectorizedArray<double> sum_hV;
       sum_hV = h1V + h2V + h3V;
       for (unsigned int i = 0; i < 2 * dim - 1 + dim / 3; i++)
         {
@@ -493,9 +491,8 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -526,13 +523,13 @@ customPDE<dim, degree>::equationLHS(
 
   // Take advantage of E being simply 0.5*(ux + transpose(ux)) and use the
   // dealii "symmetrize" function
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> E;
+  Tensor<2, dim, VectorizedArray<double>> E;
   E = symmetrize(Dux);
 
   // Compute stress tensor (which is equal to the residual, Rux)
   if (n_dependent_stiffness == true)
     {
-      dealii::Tensor<2, CIJ_tensor_size, dealii::VectorizedArray<double>> CIJ_combined;
+      Tensor<2, CIJ_tensor_size, VectorizedArray<double>> CIJ_combined;
       CIJ_combined =
         CIJ_Mg * (constV(1.0) - h1V - h2V - h3V) + CIJ_Beta * (h1V + h2V + h3V);
 

--- a/applications/precipitateEvolution/postprocess.cc
+++ b/applications/precipitateEvolution/postprocess.cc
@@ -32,9 +32,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -102,8 +104,8 @@ customPDE<dim, degree>::postProcessedFields(
 
   // Calculate the stress-free transformation strain and its derivatives at the
   // quadrature point
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts2,
-    sfts2c, sfts2cc, sfts3, sfts3c, sfts3cc;
+  Tensor<2, dim, VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts2, sfts2c, sfts2cc,
+    sfts3, sfts3c, sfts3cc;
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -130,7 +132,7 @@ customPDE<dim, degree>::postProcessedFields(
     }
 
   // compute E2=(E-E0)
-  dealii::VectorizedArray<double> E2[dim][dim], S[dim][dim];
+  VectorizedArray<double> E2[dim][dim], S[dim][dim];
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -145,11 +147,11 @@ customPDE<dim, degree>::postProcessedFields(
 
   // compute stress
   // S=C*(E-E0)
-  dealii::VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
+  VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
 
   if (n_dependent_stiffness == true)
     {
-      dealii::VectorizedArray<double> sum_hV;
+      VectorizedArray<double> sum_hV;
       sum_hV = h1V + h2V + h3V;
       for (unsigned int i = 0; i < 2 * dim - 1 + dim / 3; i++)
         {

--- a/applications/precipitateEvolution_pfunction/ICs_and_BCs.cc
+++ b/applications/precipitateEvolution_pfunction/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -70,12 +70,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/precipitateEvolution_pfunction/PLibrary/PLibrary.hh
+++ b/applications/precipitateEvolution_pfunction/PLibrary/PLibrary.hh
@@ -6,9 +6,8 @@
 #ifndef PLIBRARY_HH
 #define PLIBRARY_HH
 
-#include "IntegrationTools/PFunction.hh"
-#include "IntegrationTools/PPieceWise.hh"
-
+#include "../../../include/IntegrationTools/PFunction.hh"
+#include "../../../include/IntegrationTools/PPieceWise.hh"
 #include <cstring>
 
 namespace PRISMS

--- a/applications/precipitateEvolution_pfunction/PLibrary/pfunct_McV.hh
+++ b/applications/precipitateEvolution_pfunction/PLibrary/pfunct_McV.hh
@@ -6,8 +6,7 @@
 #ifndef pfunct_McV_HH
 #define pfunct_McV_HH
 
-#include "IntegrationTools/PFunction.hh"
-
+#include "../../../include/IntegrationTools/PFunction.hh"
 #include <cmath>
 #include <cstdlib>
 
@@ -17,7 +16,7 @@ namespace PRISMS
   class pfunct_McV_f : public PSimpleBase<VarContainer, double>
   {
     double
-    eval(const VarContainer &var) const
+    eval([[maybe_unused]] const VarContainer &var) const override
     {
       return 1.0000000000000000e+00;
     }
@@ -29,25 +28,25 @@ namespace PRISMS
     }
 
     std::string
-    csrc() const
+    csrc() const override
     {
       return "1.0000000000000000e+00";
     }
 
     std::string
-    sym() const
+    sym() const override
     {
       return "1.0";
     }
 
     std::string
-    latex() const
+    latex() const override
     {
       return "1.0";
     }
 
     pfunct_McV_f *
-    clone() const
+    clone() const override
     {
       return new pfunct_McV_f(*this);
     }
@@ -69,6 +68,7 @@ namespace PRISMS
     }
 
     pfunct_McV(const pfunct_McV &RHS)
+      : PFuncBase<double *, double>(RHS)
     {
       construct(false);
 
@@ -91,31 +91,31 @@ namespace PRISMS
     }
 
     pfunct_McV<VarContainer> *
-    clone() const
+    clone() const override
     {
       return new pfunct_McV<VarContainer>(*this);
     }
 
     PSimpleFunction<VarContainer, double>
-    simplefunction() const
+    simplefunction() const override
     {
       return PSimpleFunction<VarContainer, double>(*_val);
     }
 
     double
-    operator()(const VarContainer &var)
+    operator()(const VarContainer &var) override
     {
       return (*_val)(var);
     }
 
     void
-    eval(const VarContainer &var)
+    eval(const VarContainer &var) override
     {
       (*_val)(var);
     }
 
     double
-    operator()() const
+    operator()() const override
     {
       return (*_val)();
     }

--- a/applications/precipitateEvolution_pfunction/PLibrary/pfunct_Mn1V.hh
+++ b/applications/precipitateEvolution_pfunction/PLibrary/pfunct_Mn1V.hh
@@ -6,8 +6,7 @@
 #ifndef pfunct_Mn1V_HH
 #define pfunct_Mn1V_HH
 
-#include "IntegrationTools/PFunction.hh"
-
+#include "../../../include/IntegrationTools/PFunction.hh"
 #include <cmath>
 #include <cstdlib>
 
@@ -17,7 +16,7 @@ namespace PRISMS
   class pfunct_Mn1V_f : public PSimpleBase<VarContainer, double>
   {
     double
-    eval(const VarContainer &var) const
+    eval([[maybe_unused]] const VarContainer &var) const override
     {
       return 1.0000000000000000e+02;
     }
@@ -29,25 +28,25 @@ namespace PRISMS
     }
 
     std::string
-    csrc() const
+    csrc() const override
     {
       return "1.0000000000000000e+02";
     }
 
     std::string
-    sym() const
+    sym() const override
     {
       return "100.0";
     }
 
     std::string
-    latex() const
+    latex() const override
     {
       return "100.0";
     }
 
     pfunct_Mn1V_f *
-    clone() const
+    clone() const override
     {
       return new pfunct_Mn1V_f(*this);
     }
@@ -69,6 +68,7 @@ namespace PRISMS
     }
 
     pfunct_Mn1V(const pfunct_Mn1V &RHS)
+      : PFuncBase<double *, double>(RHS)
     {
       construct(false);
 
@@ -91,31 +91,31 @@ namespace PRISMS
     }
 
     pfunct_Mn1V<VarContainer> *
-    clone() const
+    clone() const override
     {
       return new pfunct_Mn1V<VarContainer>(*this);
     }
 
     PSimpleFunction<VarContainer, double>
-    simplefunction() const
+    simplefunction() const override
     {
       return PSimpleFunction<VarContainer, double>(*_val);
     }
 
     double
-    operator()(const VarContainer &var)
+    operator()(const VarContainer &var) override
     {
       return (*_val)(var);
     }
 
     void
-    eval(const VarContainer &var)
+    eval(const VarContainer &var) override
     {
       (*_val)(var);
     }
 
     double
-    operator()() const
+    operator()() const override
     {
       return (*_val)();
     }

--- a/applications/precipitateEvolution_pfunction/PLibrary/pfunct_Mn2V.hh
+++ b/applications/precipitateEvolution_pfunction/PLibrary/pfunct_Mn2V.hh
@@ -6,8 +6,7 @@
 #ifndef pfunct_Mn2V_HH
 #define pfunct_Mn2V_HH
 
-#include "IntegrationTools/PFunction.hh"
-
+#include "../../../include/IntegrationTools/PFunction.hh"
 #include <cmath>
 #include <cstdlib>
 
@@ -17,7 +16,7 @@ namespace PRISMS
   class pfunct_Mn2V_f : public PSimpleBase<VarContainer, double>
   {
     double
-    eval(const VarContainer &var) const
+    eval([[maybe_unused]] const VarContainer &var) const override
     {
       return 1.0000000000000000e+02;
     }
@@ -29,25 +28,25 @@ namespace PRISMS
     }
 
     std::string
-    csrc() const
+    csrc() const override
     {
       return "1.0000000000000000e+02";
     }
 
     std::string
-    sym() const
+    sym() const override
     {
       return "100.0";
     }
 
     std::string
-    latex() const
+    latex() const override
     {
       return "100.0";
     }
 
     pfunct_Mn2V_f *
-    clone() const
+    clone() const override
     {
       return new pfunct_Mn2V_f(*this);
     }
@@ -69,6 +68,7 @@ namespace PRISMS
     }
 
     pfunct_Mn2V(const pfunct_Mn2V &RHS)
+      : PFuncBase<double *, double>(RHS)
     {
       construct(false);
 
@@ -91,31 +91,31 @@ namespace PRISMS
     }
 
     pfunct_Mn2V<VarContainer> *
-    clone() const
+    clone() const override
     {
       return new pfunct_Mn2V<VarContainer>(*this);
     }
 
     PSimpleFunction<VarContainer, double>
-    simplefunction() const
+    simplefunction() const override
     {
       return PSimpleFunction<VarContainer, double>(*_val);
     }
 
     double
-    operator()(const VarContainer &var)
+    operator()(const VarContainer &var) override
     {
       return (*_val)(var);
     }
 
     void
-    eval(const VarContainer &var)
+    eval(const VarContainer &var) override
     {
       (*_val)(var);
     }
 
     double
-    operator()() const
+    operator()() const override
     {
       return (*_val)();
     }

--- a/applications/precipitateEvolution_pfunction/PLibrary/pfunct_Mn3V.hh
+++ b/applications/precipitateEvolution_pfunction/PLibrary/pfunct_Mn3V.hh
@@ -6,8 +6,7 @@
 #ifndef pfunct_Mn3V_HH
 #define pfunct_Mn3V_HH
 
-#include "IntegrationTools/PFunction.hh"
-
+#include "../../../include/IntegrationTools/PFunction.hh"
 #include <cmath>
 #include <cstdlib>
 
@@ -17,7 +16,7 @@ namespace PRISMS
   class pfunct_Mn3V_f : public PSimpleBase<VarContainer, double>
   {
     double
-    eval(const VarContainer &var) const
+    eval([[maybe_unused]] const VarContainer &var) const override
     {
       return 1.0000000000000000e+02;
     }
@@ -29,25 +28,25 @@ namespace PRISMS
     }
 
     std::string
-    csrc() const
+    csrc() const override
     {
       return "1.0000000000000000e+02";
     }
 
     std::string
-    sym() const
+    sym() const override
     {
       return "100.0";
     }
 
     std::string
-    latex() const
+    latex() const override
     {
       return "100.0";
     }
 
     pfunct_Mn3V_f *
-    clone() const
+    clone() const override
     {
       return new pfunct_Mn3V_f(*this);
     }
@@ -69,6 +68,7 @@ namespace PRISMS
     }
 
     pfunct_Mn3V(const pfunct_Mn3V &RHS)
+      : PFuncBase<double *, double>(RHS)
     {
       construct(false);
 
@@ -91,31 +91,31 @@ namespace PRISMS
     }
 
     pfunct_Mn3V<VarContainer> *
-    clone() const
+    clone() const override
     {
       return new pfunct_Mn3V<VarContainer>(*this);
     }
 
     PSimpleFunction<VarContainer, double>
-    simplefunction() const
+    simplefunction() const override
     {
       return PSimpleFunction<VarContainer, double>(*_val);
     }
 
     double
-    operator()(const VarContainer &var)
+    operator()(const VarContainer &var) override
     {
       return (*_val)(var);
     }
 
     void
-    eval(const VarContainer &var)
+    eval(const VarContainer &var) override
     {
       (*_val)(var);
     }
 
     double
-    operator()() const
+    operator()() const override
     {
       return (*_val)();
     }

--- a/applications/precipitateEvolution_pfunction/PLibrary/pfunct_faV.hh
+++ b/applications/precipitateEvolution_pfunction/PLibrary/pfunct_faV.hh
@@ -6,8 +6,7 @@
 #ifndef pfunct_faV_HH
 #define pfunct_faV_HH
 
-#include "IntegrationTools/PFunction.hh"
-
+#include "../../../include/IntegrationTools/PFunction.hh"
 #include <cmath>
 #include <cstdlib>
 
@@ -17,7 +16,7 @@ namespace PRISMS
   class pfunct_faV_f : public PSimpleBase<VarContainer, double>
   {
     double
-    eval(const VarContainer &var) const
+    eval(const VarContainer &var) const override
     {
       return 5.1622000000000003e+00 * (var[0] * var[0]) +
              -2.7374999999999998e+00 * (var[0] * var[0] * var[0]) +
@@ -33,7 +32,7 @@ namespace PRISMS
     }
 
     std::string
-    csrc() const
+    csrc() const override
     {
       return " 5.1622000000000003e+00*(var[0]*var[0])+-2.7374999999999998e+00*(var[0]*"
              "var[0]*var[0])+-4.7759999999999998e+00*var[0]+1.3687000000000000e+00*((var["
@@ -41,19 +40,19 @@ namespace PRISMS
     }
 
     std::string
-    sym() const
+    sym() const override
     {
       return "-1.6704+(1.3687)*c^4+(5.1622)*c^2-(2.7375)*c^3-(4.776)*c";
     }
 
     std::string
-    latex() const
+    latex() const override
     {
       return "-1.6704+{(5.1622)} c^{2}-{(4.776)} c-{(2.7375)} c^{3}+{(1.3687)} c^{4}";
     }
 
     pfunct_faV_f *
-    clone() const
+    clone() const override
     {
       return new pfunct_faV_f(*this);
     }
@@ -63,7 +62,7 @@ namespace PRISMS
   class pfunct_faV_grad_0 : public PSimpleBase<VarContainer, double>
   {
     double
-    eval(const VarContainer &var) const
+    eval(const VarContainer &var) const override
     {
       return 5.4748000000000001e+00 * (var[0] * var[0] * var[0]) +
              -8.2125000000000004e+00 * (var[0] * var[0]) +
@@ -77,26 +76,26 @@ namespace PRISMS
     }
 
     std::string
-    csrc() const
+    csrc() const override
     {
       return " 5.4748000000000001e+00*(var[0]*var[0]*var[0])+-8.2125000000000004e+00*("
              "var[0]*var[0])+1.0324400000000001e+01*var[0]-4.7759999999999998e+00";
     }
 
     std::string
-    sym() const
+    sym() const override
     {
       return "-4.776+(10.3244)*c+(5.4748)*c^3-(8.2125)*c^2";
     }
 
     std::string
-    latex() const
+    latex() const override
     {
       return "-4.776+{(5.4748)} c^{3}-{(8.2125)} c^{2}+{(10.3244)} c";
     }
 
     pfunct_faV_grad_0 *
-    clone() const
+    clone() const override
     {
       return new pfunct_faV_grad_0(*this);
     }
@@ -106,7 +105,7 @@ namespace PRISMS
   class pfunct_faV_hess_0_0 : public PSimpleBase<VarContainer, double>
   {
     double
-    eval(const VarContainer &var) const
+    eval(const VarContainer &var) const override
     {
       return 1.6424399999999999e+01 * (var[0] * var[0]) +
              -1.6425000000000001e+01 * var[0] + 1.0324400000000001e+01;
@@ -119,26 +118,26 @@ namespace PRISMS
     }
 
     std::string
-    csrc() const
+    csrc() const override
     {
       return " 1.6424399999999999e+01*(var[0]*var[0])+-1.6425000000000001e+01*var[0]+1."
              "0324400000000001e+01";
     }
 
     std::string
-    sym() const
+    sym() const override
     {
       return "10.3244-(16.425)*c+(16.4244)*c^2";
     }
 
     std::string
-    latex() const
+    latex() const override
     {
       return "10.3244+{(16.4244)} c^{2}-{(16.425)} c";
     }
 
     pfunct_faV_hess_0_0 *
-    clone() const
+    clone() const override
     {
       return new pfunct_faV_hess_0_0(*this);
     }
@@ -160,6 +159,7 @@ namespace PRISMS
     }
 
     pfunct_faV(const pfunct_faV &RHS)
+      : PFuncBase<double *, double>(RHS)
     {
       construct(false);
 
@@ -193,79 +193,79 @@ namespace PRISMS
     }
 
     pfunct_faV<VarContainer> *
-    clone() const
+    clone() const override
     {
       return new pfunct_faV<VarContainer>(*this);
     }
 
     PSimpleFunction<VarContainer, double>
-    simplefunction() const
+    simplefunction() const override
     {
       return PSimpleFunction<VarContainer, double>(*_val);
     }
 
     PSimpleFunction<VarContainer, double>
-    grad_simplefunction(size_type di) const
+    grad_simplefunction(size_type di) const override
     {
       return PSimpleFunction<VarContainer, double>(*_grad_val[di]);
     }
 
     PSimpleFunction<VarContainer, double>
-    hess_simplefunction(size_type di, size_type dj) const
+    hess_simplefunction(size_type di, size_type dj) const override
     {
       return PSimpleFunction<VarContainer, double>(*_hess_val[di][dj]);
     }
 
     double
-    operator()(const VarContainer &var)
+    operator()(const VarContainer &var) override
     {
       return (*_val)(var);
     }
 
     double
-    grad(const VarContainer &var, size_type di)
+    grad(const VarContainer &var, size_type di) override
     {
       return (*_grad_val[di])(var);
     }
 
     double
-    hess(const VarContainer &var, size_type di, size_type dj)
+    hess(const VarContainer &var, size_type di, size_type dj) override
     {
       return (*_hess_val[di][dj])(var);
     }
 
     void
-    eval(const VarContainer &var)
+    eval(const VarContainer &var) override
     {
       (*_val)(var);
     }
 
     void
-    eval_grad(const VarContainer &var)
+    eval_grad(const VarContainer &var) override
     {
       (*_grad_val[0])(var);
     }
 
     void
-    eval_hess(const VarContainer &var)
+    eval_hess(const VarContainer &var) override
     {
       (*_hess_val[0][0])(var);
     }
 
     double
-    operator()() const
+    operator()() const override
     {
       return (*_val)();
     }
 
     double
-    grad(size_type di) const
+    grad(size_type di) const override
     {
       return (*_grad_val[di])();
     }
 
     double
-    hess(size_type di, size_type dj) const
+    hess(size_type di, size_type dj) const override
     {
       return (*_hess_val[di][dj])();
     }

--- a/applications/precipitateEvolution_pfunction/PLibrary/pfunct_fbV.hh
+++ b/applications/precipitateEvolution_pfunction/PLibrary/pfunct_fbV.hh
@@ -6,8 +6,7 @@
 #ifndef pfunct_fbV_HH
 #define pfunct_fbV_HH
 
-#include "IntegrationTools/PFunction.hh"
-
+#include "../../../include/IntegrationTools/PFunction.hh"
 #include <cmath>
 #include <cstdlib>
 
@@ -17,7 +16,7 @@ namespace PRISMS
   class pfunct_fbV_f : public PSimpleBase<VarContainer, double>
   {
     double
-    eval(const VarContainer &var) const
+    eval(const VarContainer &var) const override
     {
       return -5.9745999999999997e+00 * var[0] +
              5.0000000000000000e+00 * (var[0] * var[0]) - 1.5924000000000000e+00;
@@ -30,26 +29,26 @@ namespace PRISMS
     }
 
     std::string
-    csrc() const
+    csrc() const override
     {
       return " -5.9745999999999997e+00*var[0]+5.0000000000000000e+00*(var[0]*var[0])-1."
              "5924000000000000e+00";
     }
 
     std::string
-    sym() const
+    sym() const override
     {
       return "-1.5924-(5.9746)*c+(5.0)*c^2";
     }
 
     std::string
-    latex() const
+    latex() const override
     {
       return "-1.5924+{(5.0)} c^{2}-{(5.9746)} c";
     }
 
     pfunct_fbV_f *
-    clone() const
+    clone() const override
     {
       return new pfunct_fbV_f(*this);
     }
@@ -59,7 +58,7 @@ namespace PRISMS
   class pfunct_fbV_grad_0 : public PSimpleBase<VarContainer, double>
   {
     double
-    eval(const VarContainer &var) const
+    eval(const VarContainer &var) const override
     {
       return 1.0000000000000000e+01 * var[0] - 5.9745999999999997e+00;
     }
@@ -71,25 +70,25 @@ namespace PRISMS
     }
 
     std::string
-    csrc() const
+    csrc() const override
     {
       return " 1.0000000000000000e+01*var[0]-5.9745999999999997e+00";
     }
 
     std::string
-    sym() const
+    sym() const override
     {
       return "-5.9746+(10.0)*c";
     }
 
     std::string
-    latex() const
+    latex() const override
     {
       return "-5.9746+{(10.0)} c";
     }
 
     pfunct_fbV_grad_0 *
-    clone() const
+    clone() const override
     {
       return new pfunct_fbV_grad_0(*this);
     }
@@ -99,7 +98,7 @@ namespace PRISMS
   class pfunct_fbV_hess_0_0 : public PSimpleBase<VarContainer, double>
   {
     double
-    eval(const VarContainer &var) const
+    eval([[maybe_unused]] const VarContainer &var) const override
     {
       return 1.0000000000000000e+01;
     }
@@ -111,25 +110,25 @@ namespace PRISMS
     }
 
     std::string
-    csrc() const
+    csrc() const override
     {
       return "1.0000000000000000e+01";
     }
 
     std::string
-    sym() const
+    sym() const override
     {
       return "10.0";
     }
 
     std::string
-    latex() const
+    latex() const override
     {
       return "10.0";
     }
 
     pfunct_fbV_hess_0_0 *
-    clone() const
+    clone() const override
     {
       return new pfunct_fbV_hess_0_0(*this);
     }
@@ -151,6 +150,7 @@ namespace PRISMS
     }
 
     pfunct_fbV(const pfunct_fbV &RHS)
+      : PFuncBase<double *, double>(RHS)
     {
       construct(false);
 
@@ -184,79 +184,79 @@ namespace PRISMS
     }
 
     pfunct_fbV<VarContainer> *
-    clone() const
+    clone() const override
     {
       return new pfunct_fbV<VarContainer>(*this);
     }
 
     PSimpleFunction<VarContainer, double>
-    simplefunction() const
+    simplefunction() const override
     {
       return PSimpleFunction<VarContainer, double>(*_val);
     }
 
     PSimpleFunction<VarContainer, double>
-    grad_simplefunction(size_type di) const
+    grad_simplefunction(size_type di) const override
     {
       return PSimpleFunction<VarContainer, double>(*_grad_val[di]);
     }
 
     PSimpleFunction<VarContainer, double>
-    hess_simplefunction(size_type di, size_type dj) const
+    hess_simplefunction(size_type di, size_type dj) const override
     {
       return PSimpleFunction<VarContainer, double>(*_hess_val[di][dj]);
     }
 
     double
-    operator()(const VarContainer &var)
+    operator()(const VarContainer &var) override
     {
       return (*_val)(var);
     }
 
     double
-    grad(const VarContainer &var, size_type di)
+    grad(const VarContainer &var, size_type di) override
     {
       return (*_grad_val[di])(var);
     }
 
     double
-    hess(const VarContainer &var, size_type di, size_type dj)
+    hess(const VarContainer &var, size_type di, size_type dj) override
     {
       return (*_hess_val[di][dj])(var);
     }
 
     void
-    eval(const VarContainer &var)
+    eval(const VarContainer &var) override
     {
       (*_val)(var);
     }
 
     void
-    eval_grad(const VarContainer &var)
+    eval_grad(const VarContainer &var) override
     {
       (*_grad_val[0])(var);
     }
 
     void
-    eval_hess(const VarContainer &var)
+    eval_hess(const VarContainer &var) override
     {
       (*_hess_val[0][0])(var);
     }
 
     double
-    operator()() const
+    operator()() const override
     {
       return (*_val)();
     }
 
     double
-    grad(size_type di) const
+    grad(size_type di) const override
     {
       return (*_grad_val[di])();
     }
 
     double
-    hess(size_type di, size_type dj) const
+    hess(size_type di, size_type dj) const override
     {
       return (*_hess_val[di][dj])();
     }

--- a/applications/precipitateEvolution_pfunction/customPDE.h
+++ b/applications/precipitateEvolution_pfunction/customPDE.h
@@ -1,7 +1,9 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 // Header files for PFunctions
-typedef dealii::VectorizedArray<double> scalarvalueType;
+typedef VectorizedArray<double> scalarvalueType;
 #include "PLibrary/PLibrary.cc"
 #include "PLibrary/PLibrary.hh"
 
@@ -21,20 +23,20 @@ public:
     , userInputs(_userInputs) {};
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -45,36 +47,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================
@@ -85,36 +93,33 @@ private:
   // Model constants specific to this subclass
   // ================================================================
 
-  dealii::Tensor<2, dim> Kn1 = userInputs.get_model_constant_rank_2_tensor("Kn1");
-  dealii::Tensor<2, dim> Kn2 = userInputs.get_model_constant_rank_2_tensor("Kn2");
-  dealii::Tensor<2, dim> Kn3 = userInputs.get_model_constant_rank_2_tensor("Kn3");
-  bool                   n_dependent_stiffness =
+  Tensor<2, dim> Kn1 = userInputs.get_model_constant_rank_2_tensor("Kn1");
+  Tensor<2, dim> Kn2 = userInputs.get_model_constant_rank_2_tensor("Kn2");
+  Tensor<2, dim> Kn3 = userInputs.get_model_constant_rank_2_tensor("Kn3");
+  bool           n_dependent_stiffness =
     userInputs.get_model_constant_bool("n_dependent_stiffness");
-  dealii::Tensor<2, dim> sfts_linear1 =
+  Tensor<2, dim> sfts_linear1 =
     userInputs.get_model_constant_rank_2_tensor("sfts_linear1");
-  dealii::Tensor<2, dim> sfts_const1 =
-    userInputs.get_model_constant_rank_2_tensor("sfts_const1");
-  dealii::Tensor<2, dim> sfts_linear2 =
+  Tensor<2, dim> sfts_const1 = userInputs.get_model_constant_rank_2_tensor("sfts_const1");
+  Tensor<2, dim> sfts_linear2 =
     userInputs.get_model_constant_rank_2_tensor("sfts_linear2");
-  dealii::Tensor<2, dim> sfts_const2 =
-    userInputs.get_model_constant_rank_2_tensor("sfts_const2");
-  dealii::Tensor<2, dim> sfts_linear3 =
+  Tensor<2, dim> sfts_const2 = userInputs.get_model_constant_rank_2_tensor("sfts_const2");
+  Tensor<2, dim> sfts_linear3 =
     userInputs.get_model_constant_rank_2_tensor("sfts_linear3");
-  dealii::Tensor<2, dim> sfts_const3 =
-    userInputs.get_model_constant_rank_2_tensor("sfts_const3");
-  double A4 = userInputs.get_model_constant_double("A4");
-  double A3 = userInputs.get_model_constant_double("A3");
-  double A2 = userInputs.get_model_constant_double("A2");
-  double A1 = userInputs.get_model_constant_double("A1");
-  double A0 = userInputs.get_model_constant_double("A0");
-  double B2 = userInputs.get_model_constant_double("B2");
-  double B1 = userInputs.get_model_constant_double("B1");
-  double B0 = userInputs.get_model_constant_double("B0");
+  Tensor<2, dim> sfts_const3 = userInputs.get_model_constant_rank_2_tensor("sfts_const3");
+  double         A4          = userInputs.get_model_constant_double("A4");
+  double         A3          = userInputs.get_model_constant_double("A3");
+  double         A2          = userInputs.get_model_constant_double("A2");
+  double         A1          = userInputs.get_model_constant_double("A1");
+  double         A0          = userInputs.get_model_constant_double("A0");
+  double         B2          = userInputs.get_model_constant_double("B2");
+  double         B1          = userInputs.get_model_constant_double("B1");
+  double         B0          = userInputs.get_model_constant_double("B0");
 
-  const static unsigned int          CIJ_tensor_size = 2 * dim - 1 + dim / 3;
-  dealii::Tensor<2, CIJ_tensor_size> CIJ_Mg =
+  const static unsigned int  CIJ_tensor_size = 2 * dim - 1 + dim / 3;
+  Tensor<2, CIJ_tensor_size> CIJ_Mg =
     userInputs.get_model_constant_elasticity_tensor("CIJ_Mg");
-  dealii::Tensor<2, CIJ_tensor_size> CIJ_Beta =
+  Tensor<2, CIJ_tensor_size> CIJ_Beta =
     userInputs.get_model_constant_elasticity_tensor("CIJ_Beta");
 
   // ================================================================

--- a/applications/precipitateEvolution_pfunction/equations.cc
+++ b/applications/precipitateEvolution_pfunction/equations.cc
@@ -77,8 +77,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -137,15 +137,6 @@ customPDE<dim, degree>::explicitEquationRHS(
   scalarvalueType fbV   = pfunct_fbV.val(c);
   scalarvalueType fbcV  = pfunct_fbV.grad(c, 0);
   scalarvalueType fbccV = pfunct_fbV.hess(c, 0, 0);
-  double          A4    = 1.3687;
-  double          A3    = -2.7375;
-  double          A2    = 5.1622;
-  double          A1    = -4.776;
-  double          A0    = -1.6704;
-
-  double B2 = 5.0;
-  double B1 = -5.9746;
-  double B0 = -1.5924;
 
   scalarvalueType h1V =
     (10.0 * n1 * n1 * n1 - 15.0 * n1 * n1 * n1 * n1 + 6.0 * n1 * n1 * n1 * n1 * n1);
@@ -162,8 +153,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 
   // Calculate the stress-free transformation strain and its derivatives at the
   // quadrature point
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts2,
-    sfts2c, sfts2cc, sfts3, sfts3c, sfts3cc;
+  Tensor<2, dim, VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts2, sfts2c, sfts2cc,
+    sfts3, sfts3c, sfts3cc;
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -190,7 +181,7 @@ customPDE<dim, degree>::explicitEquationRHS(
     }
 
   // compute E2=(E-E0)
-  dealii::VectorizedArray<double> E2[dim][dim], S[dim][dim];
+  VectorizedArray<double> E2[dim][dim], S[dim][dim];
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -204,11 +195,11 @@ customPDE<dim, degree>::explicitEquationRHS(
   // compute stress
   // S=C*(E-E0)
   //  Compute stress tensor (which is equal to the residual, Rux)
-  dealii::VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
+  VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
 
   if (n_dependent_stiffness == true)
     {
-      dealii::VectorizedArray<double> sum_hV;
+      VectorizedArray<double> sum_hV;
       sum_hV = h1V + h2V + h3V;
       for (unsigned int i = 0; i < 2 * dim - 1 + dim / 3; i++)
         {
@@ -227,9 +218,9 @@ customPDE<dim, degree>::explicitEquationRHS(
 
   // Compute one of the stress terms in the order parameter chemical potential,
   // nDependentMisfitACp = C*(E-E0)*(E0_p*Hn)
-  dealii::VectorizedArray<double> nDependentMisfitAC1 = constV(0.0);
-  dealii::VectorizedArray<double> nDependentMisfitAC2 = constV(0.0);
-  dealii::VectorizedArray<double> nDependentMisfitAC3 = constV(0.0);
+  VectorizedArray<double> nDependentMisfitAC1 = constV(0.0);
+  VectorizedArray<double> nDependentMisfitAC2 = constV(0.0);
+  VectorizedArray<double> nDependentMisfitAC3 = constV(0.0);
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -247,10 +238,10 @@ customPDE<dim, degree>::explicitEquationRHS(
 
   // Compute the other stress term in the order parameter chemical potential,
   // heterMechACp = 0.5*Hn*(C_beta-C_alpha)*(E-E0)*(E-E0)
-  dealii::VectorizedArray<double> heterMechAC1 = constV(0.0);
-  dealii::VectorizedArray<double> heterMechAC2 = constV(0.0);
-  dealii::VectorizedArray<double> heterMechAC3 = constV(0.0);
-  dealii::VectorizedArray<double> S2[dim][dim];
+  VectorizedArray<double> heterMechAC1 = constV(0.0);
+  VectorizedArray<double> heterMechAC2 = constV(0.0);
+  VectorizedArray<double> heterMechAC3 = constV(0.0);
+  VectorizedArray<double> S2[dim][dim];
 
   if (n_dependent_stiffness == true)
     {
@@ -276,7 +267,7 @@ customPDE<dim, degree>::explicitEquationRHS(
 
   if (c_dependent_misfit == true)
     {
-      dealii::VectorizedArray<double> E3[dim][dim], S3[dim][dim];
+      VectorizedArray<double> E3[dim][dim], S3[dim][dim];
 
       for (unsigned int i = 0; i < dim; i++)
         {
@@ -391,8 +382,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -423,7 +414,7 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 
   // Calculate the stress-free transformation strain and its derivatives at the
   // quadrature point
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> sfts1, sfts2, sfts3;
+  Tensor<2, dim, VectorizedArray<double>> sfts1, sfts2, sfts3;
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -442,7 +433,7 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
     }
 
   // compute E2=(E-E0)
-  dealii::VectorizedArray<double> E2[dim][dim], S[dim][dim];
+  VectorizedArray<double> E2[dim][dim], S[dim][dim];
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -456,11 +447,11 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
   // compute stress
   // S=C*(E-E0)
   //  Compute stress tensor (which is equal to the residual, Rux)
-  dealii::VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
+  VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
 
   if (n_dependent_stiffness == true)
     {
-      dealii::VectorizedArray<double> sum_hV;
+      VectorizedArray<double> sum_hV;
       sum_hV = h1V + h2V + h3V;
       for (unsigned int i = 0; i < 2 * dim - 1 + dim / 3; i++)
         {
@@ -509,8 +500,8 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -541,13 +532,13 @@ customPDE<dim, degree>::equationLHS(
 
   // Take advantage of E being simply 0.5*(ux + transpose(ux)) and use the
   // dealii "symmetrize" function
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> E;
+  Tensor<2, dim, VectorizedArray<double>> E;
   E = symmetrize(Dux);
 
   // Compute stress tensor (which is equal to the residual, Rux)
   if (n_dependent_stiffness == true)
     {
-      dealii::Tensor<2, CIJ_tensor_size, dealii::VectorizedArray<double>> CIJ_combined;
+      Tensor<2, CIJ_tensor_size, VectorizedArray<double>> CIJ_combined;
       CIJ_combined =
         CIJ_Mg * (constV(1.0) - h1V - h2V - h3V) + CIJ_Beta * (h1V + h2V + h3V);
 

--- a/applications/precipitateEvolution_pfunction/postprocess.cc
+++ b/applications/precipitateEvolution_pfunction/postprocess.cc
@@ -32,15 +32,16 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
   // The concentration and its derivatives
-  scalarvalueType c  = variable_list.get_scalar_value(0);
-  scalargradType  cx = variable_list.get_scalar_gradient(0);
+  scalarvalueType c = variable_list.get_scalar_value(0);
 
   // The first order parameter and its derivatives
   scalarvalueType n1  = variable_list.get_scalar_value(1);
@@ -103,8 +104,8 @@ customPDE<dim, degree>::postProcessedFields(
 
   // Calculate the stress-free transformation strain and its derivatives at the
   // quadrature point
-  dealii::Tensor<2, dim, dealii::VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts2,
-    sfts2c, sfts2cc, sfts3, sfts3c, sfts3cc;
+  Tensor<2, dim, VectorizedArray<double>> sfts1, sfts1c, sfts1cc, sfts2, sfts2c, sfts2cc,
+    sfts3, sfts3c, sfts3cc;
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -131,7 +132,7 @@ customPDE<dim, degree>::postProcessedFields(
     }
 
   // compute E2=(E-E0)
-  dealii::VectorizedArray<double> E2[dim][dim], S[dim][dim];
+  VectorizedArray<double> E2[dim][dim], S[dim][dim];
 
   for (unsigned int i = 0; i < dim; i++)
     {
@@ -146,11 +147,11 @@ customPDE<dim, degree>::postProcessedFields(
 
   // compute stress
   // S=C*(E-E0)
-  dealii::VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
+  VectorizedArray<double> CIJ_combined[CIJ_tensor_size][CIJ_tensor_size];
 
   if (n_dependent_stiffness == true)
     {
-      dealii::VectorizedArray<double> sum_hV;
+      VectorizedArray<double> sum_hV;
       sum_hV = h1V + h2V + h3V;
       for (unsigned int i = 0; i < 2 * dim - 1 + dim / 3; i++)
         {

--- a/applications/spinodalDecomposition/ICs_and_BCs.cc
+++ b/applications/spinodalDecomposition/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -38,12 +38,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/spinodalDecomposition/customPDE.h
+++ b/applications/spinodalDecomposition/customPDE.h
@@ -1,6 +1,8 @@
 #include "../../include/matrixFreePDE.h"
 #include <random>
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -20,20 +22,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
   typedef std::mt19937_64                        engine;
   typedef std::uniform_real_distribution<double> distribution;
@@ -47,36 +49,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/spinodalDecomposition/equations.cc
+++ b/applications/spinodalDecomposition/equations.cc
@@ -49,8 +49,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
   scalarvalueType c   = variable_list.get_scalar_value(0);
@@ -81,8 +81,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -122,6 +122,6 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {}

--- a/applications/spinodalDecomposition/postprocess.cc
+++ b/applications/spinodalDecomposition/postprocess.cc
@@ -38,9 +38,11 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::postProcessedFields(
-  const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  variableContainer<dim, degree, dealii::VectorizedArray<double>>       &pp_variable_list,
-  const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+    &variable_list,
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                            &pp_variable_list,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/steadyStateAllenCahn/ICs_and_BCs.cc
+++ b/applications/steadyStateAllenCahn/ICs_and_BCs.cc
@@ -4,10 +4,10 @@
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
-                                            const unsigned int        index,
-                                            double                   &scalar_IC,
-                                            dealii::Vector<double>   &vector_IC)
+customPDE<dim, degree>::setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                                            [[maybe_unused]] const unsigned int index,
+                                            [[maybe_unused]] double            &scalar_IC,
+                                            [[maybe_unused]] Vector<double>    &vector_IC)
 {
   // ---------------------------------------------------------------------
   // ENTER THE INITIAL CONDITIONS HERE
@@ -32,12 +32,13 @@ customPDE<dim, degree>::setInitialCondition(const dealii::Point<dim> &p,
 
 template <int dim, int degree>
 void
-customPDE<dim, degree>::setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                                                  const unsigned int        index,
-                                                  const unsigned int        direction,
-                                                  const double              time,
-                                                  double                   &scalar_BC,
-                                                  dealii::Vector<double>   &vector_BC)
+customPDE<dim, degree>::setNonUniformDirichletBCs(
+  [[maybe_unused]] const Point<dim>  &p,
+  [[maybe_unused]] const unsigned int index,
+  [[maybe_unused]] const unsigned int direction,
+  [[maybe_unused]] const double       time,
+  [[maybe_unused]] double            &scalar_BC,
+  [[maybe_unused]] Vector<double>    &vector_BC)
 {
   // --------------------------------------------------------------------------
   // ENTER THE NON-UNIFORM DIRICHLET BOUNDARY CONDITIONS HERE

--- a/applications/steadyStateAllenCahn/customPDE.h
+++ b/applications/steadyStateAllenCahn/customPDE.h
@@ -1,5 +1,7 @@
 #include "../../include/matrixFreePDE.h"
 
+using namespace dealii;
+
 template <int dim, int degree>
 class customPDE : public MatrixFreePDE<dim, degree>
 {
@@ -11,20 +13,20 @@ public:
 
   // Function to set the initial conditions (in ICs_and_BCs.h)
   void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) override;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) override;
 
   // Function to set the non-uniform Dirichlet boundary conditions (in
   // ICs_and_BCs.h)
   void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) override;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) override;
 
 private:
 #include "../../include/typeDefs.h"
@@ -35,36 +37,42 @@ private:
   // dependent equations (in equations.h)
   void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override;
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)
 #ifdef NUCLEATION_FILE_EXISTS
   double
-  getNucleationProbability(variableValueContainer variable_value,
-                           double                 dV) const override;
+  getNucleationProbability([[maybe_unused]] variableValueContainer variable_value,
+                           [[maybe_unused]] double                 dV) const override;
 #endif
 
   // ================================================================

--- a/applications/steadyStateAllenCahn/equations.cc
+++ b/applications/steadyStateAllenCahn/equations.cc
@@ -51,8 +51,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -88,8 +88,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -131,8 +131,8 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-  dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/include/IntegrationTools/pfunction/PFuncBase.hh
+++ b/include/IntegrationTools/pfunction/PFuncBase.hh
@@ -94,14 +94,15 @@ namespace PRISMS
     }
 
     virtual PSimpleFunction<VarContainer, OutType>
-    grad_simplefunction(size_type di) const
+    grad_simplefunction([[maybe_unused]] size_type di) const
     {
       undefined("PSimpleFunction<VarContainer, OutType> grad_simplefunction() const");
       return PSimpleFunction<VarContainer, OutType>();
     }
 
     virtual PSimpleFunction<VarContainer, OutType>
-    hess_simplefunction(size_type di, size_type dj) const
+    hess_simplefunction([[maybe_unused]] size_type di,
+                        [[maybe_unused]] size_type dj) const
     {
       undefined("PSimpleFunction<VarContainer, OutType> hess_simplefunction(size_type "
                 "di, size_type dj) const");
@@ -111,21 +112,23 @@ namespace PRISMS
     // ----------------------------------------------------------
     // Use these functions if you want to evaluate a single value
     virtual OutType
-    operator()(const VarContainer &var)
+    operator()([[maybe_unused]] const VarContainer &var)
     {
       undefined("OutType operator()(const VarContainer &var)");
       return OutType();
     }
 
     virtual OutType
-    grad(const VarContainer &var, size_type di)
+    grad([[maybe_unused]] const VarContainer &var, [[maybe_unused]] size_type di)
     {
       undefined("OutType grad(const VarContainer &var, size_type di)");
       return OutType();
     }
 
     virtual OutType
-    hess(const VarContainer &var, size_type di, size_type dj)
+    hess([[maybe_unused]] const VarContainer &var,
+         [[maybe_unused]] size_type           di,
+         [[maybe_unused]] size_type           dj)
     {
       undefined("OutType hess(const VarContainer &var, size_type di, size_type dj)");
       return OutType();
@@ -135,19 +138,19 @@ namespace PRISMS
     // Use these functions to evaluate several values, then use 'get' methods to access
     // results
     virtual void
-    eval(const VarContainer &var)
+    eval([[maybe_unused]] const VarContainer &var)
     {
       undefined("void eval_grad( const VarContainer &var)");
     }
 
     virtual void
-    eval_grad(const VarContainer &var)
+    eval_grad([[maybe_unused]] const VarContainer &var)
     {
       undefined("void eval_grad( const VarContainer &var)");
     }
 
     virtual void
-    eval_hess(const VarContainer &var)
+    eval_hess([[maybe_unused]] const VarContainer &var)
     {
       undefined("void eval_hess( const VarContainer &var)");
     }
@@ -160,14 +163,14 @@ namespace PRISMS
     }
 
     virtual OutType
-    grad(size_type di) const
+    grad([[maybe_unused]] size_type di) const
     {
       undefined("OutType grad(size_type di)");
       return OutType();
     }
 
     virtual OutType
-    hess(size_type di, size_type dj) const
+    hess([[maybe_unused]] size_type di, [[maybe_unused]] size_type dj) const
     {
       undefined("OutType hess(size_type di, size_type dj)");
       return OutType();

--- a/include/IntegrationTools/pfunction/PSimpleBase.hh
+++ b/include/IntegrationTools/pfunction/PSimpleBase.hh
@@ -79,7 +79,7 @@ namespace PRISMS
 
   private:
     virtual OutType
-    eval(const VarContainer &var) const
+    eval([[maybe_unused]] const VarContainer &var) const
     {
       undefined("OutType eval( const VarContainer &var)");
       return OutType();

--- a/include/matrixFreePDE.h
+++ b/include/matrixFreePDE.h
@@ -45,19 +45,18 @@
 
 #include "../src/models/mechanics/computeStress.h"
 
+using namespace dealii;
+
 // define data types
 #ifndef scalarType
-typedef dealii::VectorizedArray<double> scalarType;
+typedef VectorizedArray<double> scalarType;
 #endif
 #ifndef vectorType
-typedef dealii::LinearAlgebra::distributed::Vector<double> vectorType;
+typedef LinearAlgebra::distributed::Vector<double> vectorType;
 #endif
 
 // macro for constants
 #define constV(a) make_vectorized_array(a)
-
-//
-using namespace dealii;
 
 //
 // base class for matrix free PDE's
@@ -129,19 +128,19 @@ public:
 
   // Initial conditions function
   virtual void
-  setInitialCondition(const dealii::Point<dim> &p,
-                      const unsigned int        index,
-                      double                   &scalar_IC,
-                      dealii::Vector<double>   &vector_IC) = 0;
+  setInitialCondition([[maybe_unused]] const Point<dim>  &p,
+                      [[maybe_unused]] const unsigned int index,
+                      [[maybe_unused]] double            &scalar_IC,
+                      [[maybe_unused]] Vector<double>    &vector_IC) = 0;
 
   // Non-uniform boundary conditions function
   virtual void
-  setNonUniformDirichletBCs(const dealii::Point<dim> &p,
-                            const unsigned int        index,
-                            const unsigned int        direction,
-                            const double              time,
-                            double                   &scalar_BC,
-                            dealii::Vector<double>   &vector_BC) = 0;
+  setNonUniformDirichletBCs([[maybe_unused]] const Point<dim>  &p,
+                            [[maybe_unused]] const unsigned int index,
+                            [[maybe_unused]] const unsigned int direction,
+                            [[maybe_unused]] const double       time,
+                            [[maybe_unused]] double            &scalar_BC,
+                            [[maybe_unused]] Vector<double>    &vector_BC) = 0;
 
 protected:
   userInputParameters<dim> userInputs;
@@ -315,29 +314,33 @@ protected:
 
   virtual void
   explicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const = 0;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const = 0;
 
   virtual void
   nonExplicitEquationRHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const = 0;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                        &variable_list,
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const = 0;
 
   virtual void
-  equationLHS(
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const = 0;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                  &variable_list,
+              [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const = 0;
 
   virtual void
   postProcessedFields(
-    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    variableContainer<dim, degree, dealii::VectorizedArray<double>> &pp_variable_list,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const {};
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
+      &variable_list,
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const {};
   void
   computePostProcessedFields(std::vector<vectorType *> &postProcessedSet);
 
   void
-  getPostProcessedFields(const dealii::MatrixFree<dim, double>       &data,
+  getPostProcessedFields(const MatrixFree<dim, double>               &data,
                          std::vector<vectorType *>                   &dst,
                          const std::vector<vectorType *>             &src,
                          const std::pair<unsigned int, unsigned int> &cell_range);
@@ -345,7 +348,7 @@ protected:
   // methods to apply dirichlet BC's
   /*Map of degrees of freedom to the corresponding Dirichlet boundary
    * conditions, if any.*/
-  std::vector<std::map<dealii::types::global_dof_index, double> *> valuesDirichletSet;
+  std::vector<std::map<types::global_dof_index, double> *> valuesDirichletSet;
   /*Virtual method to mark the boundaries for applying Dirichlet boundary
    * conditions.  This is usually expected to be provided by the user.*/
   void
@@ -416,24 +419,23 @@ protected:
   void
   refineMeshNearNuclei(std::vector<nucleus<dim>> newnuclei);
   double
-  weightedDistanceFromNucleusCenter(const dealii::Point<dim, double> center,
-                                    const std::vector<double>        semiaxes,
-                                    const dealii::Point<dim, double> q_point_loc,
-                                    const unsigned int               var_index) const;
-  dealii::VectorizedArray<double>
-  weightedDistanceFromNucleusCenter(
-    const dealii::Point<dim, double>                          center,
-    const std::vector<double>                                 semiaxes,
-    const dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc,
-    const unsigned int                                        var_index) const;
+  weightedDistanceFromNucleusCenter(const Point<dim, double>  center,
+                                    const std::vector<double> semiaxes,
+                                    const Point<dim, double>  q_point_loc,
+                                    const unsigned int        var_index) const;
+  VectorizedArray<double>
+  weightedDistanceFromNucleusCenter(const Point<dim, double>                  center,
+                                    const std::vector<double>                 semiaxes,
+                                    const Point<dim, VectorizedArray<double>> q_point_loc,
+                                    const unsigned int var_index) const;
 
   // Method to obtain the nucleation probability for an element, nontrival case
   // must be implemented in the subsclass
   virtual double
   getNucleationProbability(variableValueContainer,
                            double,
-                           dealii::Point<dim>,
-                           unsigned int variable_index) const
+                           Point<dim>,
+                           [[maybe_unused]] unsigned int variable_index) const
   {
     return 0.0;
   };


### PR DESCRIPTION
Went through and fixed all warnings for each application when running `make debug`. Also fixed issue with `precipitateEvolution_pfunction` due to incorrect header path.

Closes #217.