### PR TITLE
Fixed log spacing

### DIFF
--- a/src/userInputParameters/setTimeStepList.cc
+++ b/src/userInputParameters/setTimeStepList.cc
@@ -1,4 +1,8 @@
-#include "../../include/userInputParameters.h"
+#include <deal.II/base/exceptions.h>
+
+#include "userInputParameters.h"
+
+#include <vector>
 
 template <int dim>
 std::vector<unsigned int>
@@ -7,57 +11,73 @@ userInputParameters<dim>::setTimeStepList(
   unsigned int                     numberOfOutputs,
   const std::vector<unsigned int> &userGivenTimeStepList)
 {
+  // Initialize timestep list
   std::vector<unsigned int> timeStepList;
 
+  // The number of outputs cannot be greater than the number increments
+  if (numberOfOutputs > totalIncrements)
+    {
+      numberOfOutputs = totalIncrements;
+    }
+
+  // Prevent divide by zero in subsequent output types by returning the a vector where the
+  // only entry is one greater than the number of increments. This way, we effectively
+  // have no outputs. While this condition can be ignored for the LIST type, the user
+  // should just ignore the parameter `set Number of outputs` and use the default value
+  // of 10.
+  if (numberOfOutputs == 0)
+    {
+      timeStepList.push_back(totalIncrements + 1);
+      return timeStepList;
+    }
+
+  // Set output list for all the output list types
   if (outputSpacingType == "LIST")
     {
       timeStepList = userGivenTimeStepList;
     }
-  else if (numberOfOutputs > 0)
+  else if (outputSpacingType == "EQUAL_SPACING")
     {
-      if (outputSpacingType == "EQUAL_SPACING")
+      for (unsigned int iter = 0; iter <= totalIncrements;
+           iter += totalIncrements / numberOfOutputs)
         {
-          if (numberOfOutputs > totalIncrements)
-            numberOfOutputs = totalIncrements;
+          timeStepList.push_back(iter);
+        }
+    }
+  else if (outputSpacingType == "LOG_SPACING")
+    {
+      timeStepList.push_back(0);
+      for (unsigned int output = 1; output <= numberOfOutputs; output++)
+        {
+          timeStepList.push_back(round(std::pow(static_cast<double>(totalIncrements),
+                                                static_cast<double>(output) /
+                                                  static_cast<double>(numberOfOutputs))));
+        }
+    }
+  else if (outputSpacingType == "N_PER_DECADE")
+    {
+      AssertThrow(totalIncrements > 1,
+                  dealii::ExcMessage(
+                    std::string("PRISMS-PF Error: For n per decaded spaced outputs, "
+                                "the number of increments must be greater than 1.")));
 
-          for (unsigned int iter = 0; iter <= totalIncrements;
-               iter += totalIncrements / numberOfOutputs)
+      timeStepList.push_back(0);
+      timeStepList.push_back(1);
+      for (unsigned int iter = 2; iter <= totalIncrements; iter++)
+        {
+          unsigned int decade    = std::ceil(std::log10(iter));
+          unsigned int step_size = std::pow(10, decade) / numberOfOutputs;
+          if (iter % step_size == 0)
             {
               timeStepList.push_back(iter);
-            }
-        }
-      else if (outputSpacingType == "LOG_SPACING")
-        {
-          timeStepList.push_back(0);
-          for (unsigned int output = 1; output <= numberOfOutputs; output++)
-            {
-              timeStepList.push_back(
-                round(std::pow(10,
-                               double(output) / double(numberOfOutputs) *
-                                 std::log10(totalIncrements))));
-            }
-        }
-      else if (outputSpacingType == "N_PER_DECADE")
-        {
-          timeStepList.push_back(0);
-          timeStepList.push_back(1);
-          for (unsigned int iter = 2; iter <= totalIncrements; iter++)
-            {
-              int decade    = std::ceil(std::log10(iter));
-              int step_size = (std::pow(10, decade)) / numberOfOutputs;
-              if (iter % step_size == 0)
-                {
-                  timeStepList.push_back(iter);
-                }
             }
         }
     }
   else
     {
-      // I'm not sure why this is set up this way. It seems like the intuitive
-      // thing would be to have an empty list, not a list with one entry that is
-      // higher than will be reached during time stepping.
-      timeStepList.push_back(totalIncrements + 1);
+      AssertThrow(false,
+                  dealii::ExcMessage(
+                    std::string("PRISMS-PF Error: Invalid output spacing type.")));
     }
 
   return timeStepList;

--- a/src/userInputParameters/setTimeStepList.cc
+++ b/src/userInputParameters/setTimeStepList.cc
@@ -1,7 +1,6 @@
 #include <deal.II/base/exceptions.h>
 
-#include "userInputParameters.h"
-
+#include "../../include/userInputParameters.h"
 #include <vector>
 
 template <int dim>


### PR DESCRIPTION
- Refactored parts `setTimeStepList.cc` to make it more readable. 
- If the number of outputs is set to 0, there are no outputs, regardless of the output type. Previously this was ignored for lists; however, the user should ignore the parameter and let PRISMS-PF use the default value of 10. 
- Added assertions for `N_PER_DECADE` so that the total increments is greater than 1. 
- The log spacing is working as intended. Note that our log spacing does not correspond to something like MATLAB's logspace because they begin at 10^0 while we start at 0. 

Closes #157 