### PR TITLE
Adding assertions for model constants

### DIFF
--- a/include/userInputParameters.h
+++ b/include/userInputParameters.h
@@ -5,6 +5,7 @@
 #define INCLUDE_USERINPUTPARAMETERS_H_
 
 #include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/exceptions.h>
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/vector.h>
 
@@ -52,44 +53,113 @@ public:
   // Map linking the model constant name to its index
   std::unordered_map<std::string, unsigned int> model_constant_name_map;
 
-  // Methods to access members of 'model_constant', one for each type (since one
-  // can't template based on return values) These are really just wrappers for
-  // Boost's 'get' function
+  /**
+   * \brief Retrieve the double from the `model_constants` that are defined from the
+   * parameters.prm parser. This is essentially just a wrapper for boost::get.
+   *
+   * \param constant_name Name of the constant to retrieve.
+   */
   double
   get_model_constant_double(const std::string constant_name) const
   {
+    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+           dealii::ExcMessage(
+             "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
+             "customPDE.h. The constant that you attempted to access was " +
+             constant_name + "."));
+
     return boost::get<double>(model_constants[model_constant_name_map.at(constant_name)]);
   };
 
+  /**
+   * \brief Retrieve the int from the `model_constants` that are defined from the
+   * parameters.prm parser. This is essentially just a wrapper for boost::get.
+   *
+   * \param constant_name Name of the constant to retrieve.
+   */
   int
   get_model_constant_int(const std::string constant_name) const
   {
+    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+           dealii::ExcMessage(
+             "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
+             "customPDE.h. The constant that you attempted to access was " +
+             constant_name + "."));
+
     return boost::get<int>(model_constants[model_constant_name_map.at(constant_name)]);
   };
 
+  /**
+   * \brief Retrieve the bool from the `model_constants` that are defined from the
+   * parameters.prm parser. This is essentially just a wrapper for boost::get.
+   *
+   * \param constant_name Name of the constant to retrieve.
+   */
   bool
   get_model_constant_bool(const std::string constant_name) const
   {
+    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+           dealii::ExcMessage(
+             "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
+             "customPDE.h. The constant that you attempted to access was " +
+             constant_name + "."));
+
     return boost::get<bool>(model_constants[model_constant_name_map.at(constant_name)]);
   };
 
+  /**
+   * \brief Retrieve the rank 1 tensor from the `model_constants` that are defined from
+   * the parameters.prm parser. This is essentially just a wrapper for boost::get.
+   *
+   * \param constant_name Name of the constant to retrieve.
+   */
   dealii::Tensor<1, dim>
   get_model_constant_rank_1_tensor(const std::string constant_name) const
   {
+    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+           dealii::ExcMessage(
+             "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
+             "customPDE.h. The constant that you attempted to access was " +
+             constant_name + "."));
+
     return boost::get<dealii::Tensor<1, dim>>(
       model_constants[model_constant_name_map.at(constant_name)]);
   };
 
+  /**
+   * \brief Retrieve the rank 2 tensor from the `model_constants` that are defined from
+   * the parameters.prm parser. This is essentially just a wrapper for boost::get.
+   *
+   * \param constant_name Name of the constant to retrieve.
+   */
   dealii::Tensor<2, dim>
   get_model_constant_rank_2_tensor(const std::string constant_name) const
   {
+    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+           dealii::ExcMessage(
+             "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
+             "customPDE.h. The constant that you attempted to access was " +
+             constant_name + "."));
+
     return boost::get<dealii::Tensor<2, dim>>(
       model_constants[model_constant_name_map.at(constant_name)]);
   };
 
+  /**
+   * \brief Retrieve the elasticity tensor from the `model_constants` that are defined
+   * from the parameters.prm parser. This is essentially just a wrapper for boost::get.
+   *
+   * \param constant_name Name of the constant to retrieve.
+   */
   dealii::Tensor<2, 2 * dim - 1 + dim / 3>
   get_model_constant_elasticity_tensor(const std::string constant_name) const
   {
+    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+           dealii::ExcMessage(
+             "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
+             "customPDE.h. The constant that you attempted to access was " +
+             constant_name + "."));
+
     return boost::get<dealii::Tensor<2, 2 * dim - 1 + dim / 3>>(
       model_constants[model_constant_name_map.at(constant_name)]);
   };


### PR DESCRIPTION
Added assertions for when we try to access an invalid map entry in `model_constants`.

Say we have:
```
double MnV = userInputs.get_model_constant_double("not_a_variable");
```
This will throw this error when compiled in debug mode:
```
The violated condition was: 
    model_constant_name_map.find(constant_name) != model_constant_name_map.end()
Additional information: 
    PRISMS-PF Error: Mismatch between constants in parameters.prm and
    customPDE.h. The constant that you attempted to access was not_a_variable.
```

Closes #102 