### PR TITLE
Method to compute element volume

### DIFF
--- a/applications/CHAC_anisotropy/customPDE.h
+++ b/applications/CHAC_anisotropy/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHAC_anisotropy/customPDE.h
+++ b/applications/CHAC_anisotropy/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/CHAC_anisotropy/customPDE.h
+++ b/applications/CHAC_anisotropy/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHAC_anisotropy/equations.cc
+++ b/applications/CHAC_anisotropy/equations.cc
@@ -51,7 +51,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -152,7 +152,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -175,5 +175,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHAC_anisotropy/equations.cc
+++ b/applications/CHAC_anisotropy/equations.cc
@@ -50,7 +50,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -150,7 +151,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -172,5 +174,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHAC_anisotropy/postprocess.cc
+++ b/applications/CHAC_anisotropy/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
   // c

--- a/applications/CHAC_anisotropy/postprocess.cc
+++ b/applications/CHAC_anisotropy/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
   // c

--- a/applications/CHAC_anisotropyRegularized/customPDE.h
+++ b/applications/CHAC_anisotropyRegularized/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHAC_anisotropyRegularized/customPDE.h
+++ b/applications/CHAC_anisotropyRegularized/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/CHAC_anisotropyRegularized/customPDE.h
+++ b/applications/CHAC_anisotropyRegularized/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHAC_anisotropyRegularized/equations.cc
+++ b/applications/CHAC_anisotropyRegularized/equations.cc
@@ -58,7 +58,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -163,7 +164,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -194,5 +196,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHAC_anisotropyRegularized/equations.cc
+++ b/applications/CHAC_anisotropyRegularized/equations.cc
@@ -59,7 +59,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -165,7 +165,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -197,5 +197,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHAC_anisotropyRegularized/postprocess.cc
+++ b/applications/CHAC_anisotropyRegularized/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHAC_anisotropyRegularized/postprocess.cc
+++ b/applications/CHAC_anisotropyRegularized/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHAC_performance_test/customPDE.h
+++ b/applications/CHAC_performance_test/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHAC_performance_test/customPDE.h
+++ b/applications/CHAC_performance_test/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/CHAC_performance_test/customPDE.h
+++ b/applications/CHAC_performance_test/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHAC_performance_test/equations.cc
+++ b/applications/CHAC_performance_test/equations.cc
@@ -50,7 +50,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -111,7 +112,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -133,5 +135,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHAC_performance_test/equations.cc
+++ b/applications/CHAC_performance_test/equations.cc
@@ -51,7 +51,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -113,7 +113,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -136,5 +136,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHAC_performance_test/postprocess.cc
+++ b/applications/CHAC_performance_test/postprocess.cc
@@ -41,7 +41,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHAC_performance_test/postprocess.cc
+++ b/applications/CHAC_performance_test/postprocess.cc
@@ -40,7 +40,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/equations.cc
@@ -50,7 +50,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -89,7 +90,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -132,5 +134,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/equations.cc
@@ -51,7 +51,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -91,7 +91,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -135,5 +135,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/equations.cc
@@ -50,7 +50,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -89,7 +90,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -132,5 +134,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/equations.cc
@@ -51,7 +51,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -91,7 +91,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -135,5 +135,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/customPDE.h
@@ -68,8 +68,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/customPDE.h
@@ -42,7 +42,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -51,14 +51,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -69,7 +70,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/customPDE.h
@@ -40,23 +40,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/equations.cc
@@ -50,7 +50,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -89,7 +90,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -132,5 +134,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/equations.cc
@@ -51,7 +51,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -91,7 +91,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -135,5 +135,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/equations.cc
@@ -83,7 +83,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -185,7 +185,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -241,5 +241,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/equations.cc
@@ -82,7 +82,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -183,7 +184,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -238,5 +240,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/postprocess.cc
@@ -44,7 +44,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/postprocess.cc
@@ -45,7 +45,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/equations.cc
@@ -58,7 +58,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -118,7 +119,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -187,5 +189,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/equations.cc
@@ -59,7 +59,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -120,7 +120,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -190,5 +190,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/equations.cc
@@ -60,7 +60,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -99,7 +100,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -152,7 +154,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/equations.cc
@@ -61,7 +61,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -101,7 +101,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -155,7 +155,7 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/customPDE.h
@@ -43,7 +43,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -52,14 +52,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -70,7 +71,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/customPDE.h
@@ -41,23 +41,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/customPDE.h
@@ -69,8 +69,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/equations.cc
@@ -61,7 +61,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -101,7 +101,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -155,7 +155,7 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // grad(delta phi)
   scalargradType Dphix = variable_list.get_change_in_scalar_gradient(2);

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/equations.cc
@@ -60,7 +60,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -99,7 +100,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -152,7 +154,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // grad(delta phi)
   scalargradType Dphix = variable_list.get_change_in_scalar_gradient(2);

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/customPDE.h
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/equations.cc
@@ -42,7 +42,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -105,7 +106,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -127,5 +129,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/equations.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/equations.cc
@@ -43,7 +43,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -107,7 +107,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -130,5 +130,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/postprocess.cc
@@ -69,7 +69,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/postprocess.cc
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/postprocess.cc
@@ -70,7 +70,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/MgNd_precipitate_single_Bppp/customPDE.h
+++ b/applications/MgNd_precipitate_single_Bppp/customPDE.h
@@ -50,23 +50,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/MgNd_precipitate_single_Bppp/customPDE.h
+++ b/applications/MgNd_precipitate_single_Bppp/customPDE.h
@@ -52,7 +52,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -61,14 +61,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -79,7 +80,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/MgNd_precipitate_single_Bppp/customPDE.h
+++ b/applications/MgNd_precipitate_single_Bppp/customPDE.h
@@ -78,8 +78,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/MgNd_precipitate_single_Bppp/equations.cc
+++ b/applications/MgNd_precipitate_single_Bppp/equations.cc
@@ -69,7 +69,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -252,7 +252,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -403,7 +403,7 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/MgNd_precipitate_single_Bppp/equations.cc
+++ b/applications/MgNd_precipitate_single_Bppp/equations.cc
@@ -68,7 +68,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -250,7 +251,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -400,7 +402,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/MgNd_precipitate_single_Bppp/postprocess.cc
+++ b/applications/MgNd_precipitate_single_Bppp/postprocess.cc
@@ -51,7 +51,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/MgNd_precipitate_single_Bppp/postprocess.cc
+++ b/applications/MgNd_precipitate_single_Bppp/postprocess.cc
@@ -52,7 +52,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/advection/customPDE.h
+++ b/applications/advection/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.cc)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.cc)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/advection/customPDE.h
+++ b/applications/advection/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/advection/customPDE.h
+++ b/applications/advection/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.cc)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.cc)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/advection/equations.cc
+++ b/applications/advection/equations.cc
@@ -43,7 +43,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -64,7 +64,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // Getting necessary variables
   scalarvalueType n     = variable_list.get_scalar_value(0);
@@ -108,7 +108,7 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // Getting necessary variables
   scalarvalueType change_n  = variable_list.get_change_in_scalar_value(0);

--- a/applications/advection/equations.cc
+++ b/applications/advection/equations.cc
@@ -42,7 +42,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -62,7 +63,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // Getting necessary variables
   scalarvalueType n     = variable_list.get_scalar_value(0);
@@ -105,7 +107,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // Getting necessary variables
   scalarvalueType change_n  = variable_list.get_change_in_scalar_value(0);

--- a/applications/allenCahn/customPDE.h
+++ b/applications/allenCahn/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.cc)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.cc)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/allenCahn/customPDE.h
+++ b/applications/allenCahn/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/allenCahn/customPDE.h
+++ b/applications/allenCahn/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.cc)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.cc)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/allenCahn/equations.cc
+++ b/applications/allenCahn/equations.cc
@@ -43,7 +43,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -81,7 +81,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -104,5 +104,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/allenCahn/equations.cc
+++ b/applications/allenCahn/equations.cc
@@ -42,7 +42,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -79,7 +80,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -101,5 +103,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/allenCahn/postprocess.cc
+++ b/applications/allenCahn/postprocess.cc
@@ -50,7 +50,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/allenCahn/postprocess.cc
+++ b/applications/allenCahn/postprocess.cc
@@ -49,7 +49,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/allenCahn_conserved/customPDE.h
+++ b/applications/allenCahn_conserved/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.cc)

--- a/applications/allenCahn_conserved/customPDE.h
+++ b/applications/allenCahn_conserved/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.cc)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.cc)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/allenCahn_conserved/customPDE.h
+++ b/applications/allenCahn_conserved/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.cc)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.cc)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.cc)

--- a/applications/allenCahn_conserved/equations.cc
+++ b/applications/allenCahn_conserved/equations.cc
@@ -50,7 +50,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -90,7 +90,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // The order parameter and its derivatives
   scalarvalueType n  = variable_list.get_scalar_value(0);
@@ -131,5 +131,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/allenCahn_conserved/equations.cc
+++ b/applications/allenCahn_conserved/equations.cc
@@ -49,7 +49,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -88,7 +89,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // The order parameter and its derivatives
   scalarvalueType n  = variable_list.get_scalar_value(0);
@@ -128,5 +130,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/allenCahn_conserved/postprocess.cc
+++ b/applications/allenCahn_conserved/postprocess.cc
@@ -50,7 +50,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/allenCahn_conserved/postprocess.cc
+++ b/applications/allenCahn_conserved/postprocess.cc
@@ -49,7 +49,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/alloySolidification/customPDE.h
+++ b/applications/alloySolidification/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/alloySolidification/customPDE.h
+++ b/applications/alloySolidification/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/alloySolidification/customPDE.h
+++ b/applications/alloySolidification/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/alloySolidification/equations.cc
+++ b/applications/alloySolidification/equations.cc
@@ -58,7 +58,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -156,7 +157,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -243,5 +245,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/alloySolidification/equations.cc
+++ b/applications/alloySolidification/equations.cc
@@ -59,7 +59,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -158,7 +158,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -246,5 +246,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/alloySolidification/postprocess.cc
+++ b/applications/alloySolidification/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/alloySolidification/postprocess.cc
+++ b/applications/alloySolidification/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/alloySolidification_uniform/customPDE.h
+++ b/applications/alloySolidification_uniform/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/alloySolidification_uniform/customPDE.h
+++ b/applications/alloySolidification_uniform/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/alloySolidification_uniform/customPDE.h
+++ b/applications/alloySolidification_uniform/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/alloySolidification_uniform/equations.cc
+++ b/applications/alloySolidification_uniform/equations.cc
@@ -58,7 +58,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -156,7 +157,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -238,5 +240,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/alloySolidification_uniform/equations.cc
+++ b/applications/alloySolidification_uniform/equations.cc
@@ -59,7 +59,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -158,7 +158,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -241,5 +241,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/anisotropyFacet/customPDE.h
+++ b/applications/anisotropyFacet/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/anisotropyFacet/customPDE.h
+++ b/applications/anisotropyFacet/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/anisotropyFacet/customPDE.h
+++ b/applications/anisotropyFacet/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/anisotropyFacet/equations.cc
+++ b/applications/anisotropyFacet/equations.cc
@@ -61,7 +61,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -145,7 +145,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -177,5 +177,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/anisotropyFacet/equations.cc
+++ b/applications/anisotropyFacet/equations.cc
@@ -60,7 +60,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -143,7 +144,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -174,5 +176,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/anisotropyFacet/postprocess.cc
+++ b/applications/anisotropyFacet/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/anisotropyFacet/postprocess.cc
+++ b/applications/anisotropyFacet/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/cahnHilliard/customPDE.h
+++ b/applications/cahnHilliard/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/cahnHilliard/customPDE.h
+++ b/applications/cahnHilliard/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/cahnHilliard/customPDE.h
+++ b/applications/cahnHilliard/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/cahnHilliard/equations.cc
+++ b/applications/cahnHilliard/equations.cc
@@ -51,7 +51,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
   scalarvalueType c   = variable_list.get_scalar_value(0);
@@ -84,7 +84,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -126,5 +126,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/cahnHilliard/equations.cc
+++ b/applications/cahnHilliard/equations.cc
@@ -50,7 +50,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
   scalarvalueType c   = variable_list.get_scalar_value(0);
@@ -82,7 +83,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -123,5 +125,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/cahnHilliard/postprocess.cc
+++ b/applications/cahnHilliard/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/cahnHilliard/postprocess.cc
+++ b/applications/cahnHilliard/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/corrosion/customPDE.h
+++ b/applications/corrosion/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/corrosion/customPDE.h
+++ b/applications/corrosion/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/corrosion/customPDE.h
+++ b/applications/corrosion/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/corrosion/equations.cc
+++ b/applications/corrosion/equations.cc
@@ -103,7 +103,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Parameters in the explicit equations can be set here  ---
 
@@ -231,7 +231,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -374,7 +374,7 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // The order parameter and its derivatives
   scalarvalueType n = variable_list.get_scalar_value(0);

--- a/applications/corrosion/equations.cc
+++ b/applications/corrosion/equations.cc
@@ -102,7 +102,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Parameters in the explicit equations can be set here  ---
 
@@ -229,7 +230,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -371,7 +373,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // The order parameter and its derivatives
   scalarvalueType n = variable_list.get_scalar_value(0);

--- a/applications/corrosion_microgalvanic/customPDE.h
+++ b/applications/corrosion_microgalvanic/customPDE.h
@@ -42,8 +42,8 @@ private:
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                                 &variable_list,
-    [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations
   // for all other equations (in equations.h)
@@ -51,15 +51,16 @@ private:
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                                 &variable_list,
-    [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                          &variable_list,
-              [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                &variable_list,
+    [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set postprocessing expressions (in postprocess.h)
 
@@ -70,8 +71,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                                       &pp_variable_list,
-    [[maybe_unused]] const dealii::Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const dealii::Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/corrosion_microgalvanic/customPDE.h
+++ b/applications/corrosion_microgalvanic/customPDE.h
@@ -41,8 +41,8 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                &variable_list,
-    [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc,
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
     [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations
@@ -50,16 +50,16 @@ private:
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                &variable_list,
-    [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc,
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
     [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                &variable_list,
-    [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc,
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
     [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set postprocessing expressions (in postprocess.h)
@@ -70,8 +70,8 @@ private:
     [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                      &pp_variable_list,
-    [[maybe_unused]] const dealii::Point<dim, VectorizedArray<double>> q_point_loc,
+                                                              &pp_variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
     [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 

--- a/applications/corrosion_microgalvanic/customPDE.h
+++ b/applications/corrosion_microgalvanic/customPDE.h
@@ -40,26 +40,25 @@ private:
 
   void
   explicitEquationRHS(
-    [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                        &variable_list,
-    [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc)
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                &variable_list,
+    [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc)
     const override;
 
   // Function to set the RHS of the governing equations
   // for all other equations (in equations.h)
   void
   nonExplicitEquationRHS(
-    [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                        &variable_list,
-    [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc)
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                &variable_list,
+    [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc)
     const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                        &variable_list,
-    [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc)
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                          &variable_list,
+              [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc)
     const override;
 
   // Function to set postprocessing expressions (in postprocess.h)
@@ -67,12 +66,12 @@ private:
 #ifdef POSTPROCESS_FILE_EXISTS
   void
   postProcessedFields(
-    [[maybe_unused]] const variableContainer<dim, degree, dealii::VectorizedArray<double>>
+    [[maybe_unused]] const variableContainer<dim, degree, VectorizedArray<double>>
       &variable_list,
-    [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-      &pp_variable_list,
-    [[maybe_unused]] const dealii::Point<dim, dealii::VectorizedArray<double>>
-      q_point_loc) const override;
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                      &pp_variable_list,
+    [[maybe_unused]] const dealii::Point<dim, VectorizedArray<double>> q_point_loc)
+    const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/corrosion_microgalvanic/equations.cc
+++ b/applications/corrosion_microgalvanic/equations.cc
@@ -122,9 +122,8 @@ variableAttributeLoader::loadVariableAttributes()
 template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Parameters in the explicit equations can be set here  ---
 
@@ -255,9 +254,8 @@ customPDE<dim, degree>::explicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -396,9 +394,8 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
-  [[maybe_unused]] variableContainer<dim, degree, dealii::VectorizedArray<double>>
-                                                                      &variable_list,
-  [[maybe_unused]] dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
+  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc) const
 {
   // The order parameter of the anodic phase
   scalarvalueType nAnodic = variable_list.get_scalar_value(0);

--- a/applications/corrosion_microgalvanic/equations.cc
+++ b/applications/corrosion_microgalvanic/equations.cc
@@ -123,7 +123,7 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>>              q_point_loc,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
   [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Parameters in the explicit equations can be set here  ---
@@ -256,7 +256,7 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>>              q_point_loc,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
   [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
@@ -397,7 +397,7 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>>              q_point_loc,
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
   [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // The order parameter of the anodic phase

--- a/applications/corrosion_microgalvanic/equations.cc
+++ b/applications/corrosion_microgalvanic/equations.cc
@@ -123,7 +123,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>>              q_point_loc,
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Parameters in the explicit equations can be set here  ---
 
@@ -255,7 +256,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>>              q_point_loc,
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -395,7 +397,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] dealii::Point<dim, VectorizedArray<double>>              q_point_loc,
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // The order parameter of the anodic phase
   scalarvalueType nAnodic = variable_list.get_scalar_value(0);

--- a/applications/coupledCahnHilliardAllenCahn/customPDE.h
+++ b/applications/coupledCahnHilliardAllenCahn/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/coupledCahnHilliardAllenCahn/customPDE.h
+++ b/applications/coupledCahnHilliardAllenCahn/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/coupledCahnHilliardAllenCahn/customPDE.h
+++ b/applications/coupledCahnHilliardAllenCahn/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/coupledCahnHilliardAllenCahn/equations.cc
+++ b/applications/coupledCahnHilliardAllenCahn/equations.cc
@@ -50,7 +50,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -112,7 +113,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -134,5 +136,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/coupledCahnHilliardAllenCahn/equations.cc
+++ b/applications/coupledCahnHilliardAllenCahn/equations.cc
@@ -51,7 +51,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -114,7 +114,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -137,5 +137,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/coupledCahnHilliardAllenCahn/postprocess.cc
+++ b/applications/coupledCahnHilliardAllenCahn/postprocess.cc
@@ -50,7 +50,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/coupledCahnHilliardAllenCahn/postprocess.cc
+++ b/applications/coupledCahnHilliardAllenCahn/postprocess.cc
@@ -49,7 +49,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/dendriticSolidification/customPDE.h
+++ b/applications/dendriticSolidification/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/dendriticSolidification/customPDE.h
+++ b/applications/dendriticSolidification/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/dendriticSolidification/customPDE.h
+++ b/applications/dendriticSolidification/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/dendriticSolidification/equations.cc
+++ b/applications/dendriticSolidification/equations.cc
@@ -59,7 +59,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -122,7 +122,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -192,5 +192,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/dendriticSolidification/equations.cc
+++ b/applications/dendriticSolidification/equations.cc
@@ -58,7 +58,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -120,7 +121,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -189,5 +191,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/eshelbyInclusion/customPDE.h
+++ b/applications/eshelbyInclusion/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/eshelbyInclusion/customPDE.h
+++ b/applications/eshelbyInclusion/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/eshelbyInclusion/customPDE.h
+++ b/applications/eshelbyInclusion/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/eshelbyInclusion/equations.cc
+++ b/applications/eshelbyInclusion/equations.cc
@@ -44,7 +44,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -64,7 +65,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -151,7 +153,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/eshelbyInclusion/equations.cc
+++ b/applications/eshelbyInclusion/equations.cc
@@ -45,7 +45,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -66,7 +66,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -154,7 +154,7 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/fickianDiffusion/customPDE.h
+++ b/applications/fickianDiffusion/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/fickianDiffusion/customPDE.h
+++ b/applications/fickianDiffusion/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/fickianDiffusion/customPDE.h
+++ b/applications/fickianDiffusion/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/fickianDiffusion/equations.cc
+++ b/applications/fickianDiffusion/equations.cc
@@ -42,7 +42,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -105,7 +106,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -127,5 +129,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/fickianDiffusion/equations.cc
+++ b/applications/fickianDiffusion/equations.cc
@@ -43,7 +43,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -107,7 +107,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -130,5 +130,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/grainGrowth/customPDE.h
+++ b/applications/grainGrowth/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/grainGrowth/customPDE.h
+++ b/applications/grainGrowth/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/grainGrowth/customPDE.h
+++ b/applications/grainGrowth/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/grainGrowth/equations.cc
+++ b/applications/grainGrowth/equations.cc
@@ -50,7 +50,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -114,7 +114,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -137,5 +137,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/grainGrowth/equations.cc
+++ b/applications/grainGrowth/equations.cc
@@ -49,7 +49,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -112,7 +113,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -134,5 +136,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/grainGrowth/postprocess.cc
+++ b/applications/grainGrowth/postprocess.cc
@@ -50,7 +50,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/grainGrowth/postprocess.cc
+++ b/applications/grainGrowth/postprocess.cc
@@ -49,7 +49,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/grainGrowth_dream3d/customPDE.h
+++ b/applications/grainGrowth_dream3d/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/grainGrowth_dream3d/customPDE.h
+++ b/applications/grainGrowth_dream3d/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/grainGrowth_dream3d/customPDE.h
+++ b/applications/grainGrowth_dream3d/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/grainGrowth_dream3d/equations.cc
+++ b/applications/grainGrowth_dream3d/equations.cc
@@ -61,7 +61,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -125,7 +125,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -148,5 +148,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/grainGrowth_dream3d/equations.cc
+++ b/applications/grainGrowth_dream3d/equations.cc
@@ -60,7 +60,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -123,7 +124,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -145,5 +147,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/grainGrowth_dream3d/postprocess.cc
+++ b/applications/grainGrowth_dream3d/postprocess.cc
@@ -61,7 +61,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/grainGrowth_dream3d/postprocess.cc
+++ b/applications/grainGrowth_dream3d/postprocess.cc
@@ -62,7 +62,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/mechanics/customPDE.h
+++ b/applications/mechanics/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/mechanics/customPDE.h
+++ b/applications/mechanics/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/mechanics/customPDE.h
+++ b/applications/mechanics/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/mechanics/equations.cc
+++ b/applications/mechanics/equations.cc
@@ -36,7 +36,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -57,7 +57,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -115,7 +115,7 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/mechanics/equations.cc
+++ b/applications/mechanics/equations.cc
@@ -35,7 +35,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -55,7 +56,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -112,7 +114,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/nucleationModel/customPDE.h
+++ b/applications/nucleationModel/customPDE.h
@@ -65,8 +65,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Virtual method in MatrixFreePDE that we override if we need nucleation

--- a/applications/nucleationModel/customPDE.h
+++ b/applications/nucleationModel/customPDE.h
@@ -37,23 +37,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/nucleationModel/customPDE.h
+++ b/applications/nucleationModel/customPDE.h
@@ -39,7 +39,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -48,14 +48,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -66,7 +67,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Virtual method in MatrixFreePDE that we override if we need nucleation

--- a/applications/nucleationModel/equations.cc
+++ b/applications/nucleationModel/equations.cc
@@ -56,7 +56,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -199,7 +200,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -221,5 +223,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/nucleationModel/equations.cc
+++ b/applications/nucleationModel/equations.cc
@@ -57,7 +57,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -201,7 +201,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -224,5 +224,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/nucleationModel_preferential/customPDE.h
+++ b/applications/nucleationModel_preferential/customPDE.h
@@ -65,8 +65,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Virtual method in MatrixFreePDE that we override if we need nucleation

--- a/applications/nucleationModel_preferential/customPDE.h
+++ b/applications/nucleationModel_preferential/customPDE.h
@@ -37,23 +37,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/nucleationModel_preferential/customPDE.h
+++ b/applications/nucleationModel_preferential/customPDE.h
@@ -39,7 +39,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -48,14 +48,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -66,7 +67,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Virtual method in MatrixFreePDE that we override if we need nucleation

--- a/applications/nucleationModel_preferential/equations.cc
+++ b/applications/nucleationModel_preferential/equations.cc
@@ -56,7 +56,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -200,7 +201,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -222,5 +224,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/nucleationModel_preferential/equations.cc
+++ b/applications/nucleationModel_preferential/equations.cc
@@ -57,7 +57,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -202,7 +202,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -225,5 +225,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/precipitateEvolution/customPDE.h
+++ b/applications/precipitateEvolution/customPDE.h
@@ -36,23 +36,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/precipitateEvolution/customPDE.h
+++ b/applications/precipitateEvolution/customPDE.h
@@ -38,7 +38,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -47,14 +47,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -65,7 +66,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/precipitateEvolution/customPDE.h
+++ b/applications/precipitateEvolution/customPDE.h
@@ -64,8 +64,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/precipitateEvolution/equations.cc
+++ b/applications/precipitateEvolution/equations.cc
@@ -78,7 +78,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -374,7 +375,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -492,7 +494,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/precipitateEvolution/equations.cc
+++ b/applications/precipitateEvolution/equations.cc
@@ -79,7 +79,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -376,7 +376,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -495,7 +495,7 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/precipitateEvolution/postprocess.cc
+++ b/applications/precipitateEvolution/postprocess.cc
@@ -36,7 +36,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/precipitateEvolution/postprocess.cc
+++ b/applications/precipitateEvolution/postprocess.cc
@@ -37,7 +37,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/precipitateEvolution_pfunction/customPDE.h
+++ b/applications/precipitateEvolution_pfunction/customPDE.h
@@ -49,7 +49,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -58,14 +58,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -76,7 +77,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/precipitateEvolution_pfunction/customPDE.h
+++ b/applications/precipitateEvolution_pfunction/customPDE.h
@@ -47,23 +47,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/precipitateEvolution_pfunction/customPDE.h
+++ b/applications/precipitateEvolution_pfunction/customPDE.h
@@ -75,8 +75,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/precipitateEvolution_pfunction/equations.cc
+++ b/applications/precipitateEvolution_pfunction/equations.cc
@@ -79,7 +79,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -385,7 +385,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -504,7 +504,7 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/precipitateEvolution_pfunction/equations.cc
+++ b/applications/precipitateEvolution_pfunction/equations.cc
@@ -78,7 +78,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -383,7 +384,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -501,7 +503,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/precipitateEvolution_pfunction/postprocess.cc
+++ b/applications/precipitateEvolution_pfunction/postprocess.cc
@@ -36,7 +36,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/precipitateEvolution_pfunction/postprocess.cc
+++ b/applications/precipitateEvolution_pfunction/postprocess.cc
@@ -37,7 +37,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/spinodalDecomposition/customPDE.h
+++ b/applications/spinodalDecomposition/customPDE.h
@@ -79,8 +79,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/spinodalDecomposition/customPDE.h
+++ b/applications/spinodalDecomposition/customPDE.h
@@ -53,7 +53,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -62,14 +62,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -80,7 +81,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/applications/spinodalDecomposition/customPDE.h
+++ b/applications/spinodalDecomposition/customPDE.h
@@ -51,23 +51,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/applications/spinodalDecomposition/equations.cc
+++ b/applications/spinodalDecomposition/equations.cc
@@ -51,7 +51,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
   scalarvalueType c   = variable_list.get_scalar_value(0);
@@ -84,7 +84,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -126,5 +126,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/applications/spinodalDecomposition/equations.cc
+++ b/applications/spinodalDecomposition/equations.cc
@@ -50,7 +50,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
   scalarvalueType c   = variable_list.get_scalar_value(0);
@@ -82,7 +83,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -123,5 +125,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/applications/spinodalDecomposition/postprocess.cc
+++ b/applications/spinodalDecomposition/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/applications/spinodalDecomposition/postprocess.cc
+++ b/applications/spinodalDecomposition/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/include/matrixFreePDE.h
+++ b/include/matrixFreePDE.h
@@ -344,22 +344,22 @@ protected:
   virtual void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double>             element_volume) const = 0;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double>             element_volume) const = 0;
 
   virtual void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double>             element_volume) const = 0;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double>             element_volume) const = 0;
 
   virtual void
   equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                  &variable_list,
-              [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const = 0;
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] const VectorizedArray<double> element_volume) const = 0;
 
   virtual void
   postProcessedFields(
@@ -368,7 +368,7 @@ protected:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double>                   element_volume) const {};
+    [[maybe_unused]] const VectorizedArray<double>             element_volume) const {};
   void
   computePostProcessedFields(std::vector<vectorType *> &postProcessedSet);
 

--- a/include/matrixFreePDE.h
+++ b/include/matrixFreePDE.h
@@ -277,6 +277,17 @@ protected:
   applyBCs(unsigned int fieldIndex);
 
   /**
+   * \brief Compute element volume for the triangulation
+   */
+  void
+  compute_element_volume();
+
+  /**
+   * \brief Vector that stores element volumes
+   */
+  dealii::AlignedVector<dealii::VectorizedArray<double>> element_volume;
+
+  /**
    * \brief Copy the solutions from the current timestep to previous time states.
    */
   void
@@ -334,18 +345,21 @@ protected:
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                         &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const = 0;
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] dealii::VectorizedArray<double>     element_volume) const = 0;
 
   virtual void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                         &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const = 0;
+    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] dealii::VectorizedArray<double>     element_volume) const = 0;
 
   virtual void
   equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                                   &variable_list,
-              [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const = 0;
+              [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] dealii::VectorizedArray<double> element_volume) const = 0;
 
   virtual void
   postProcessedFields(
@@ -353,7 +367,8 @@ protected:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const {};
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] dealii::VectorizedArray<double>           element_volume) const {};
   void
   computePostProcessedFields(std::vector<vectorType *> &postProcessedSet);
 

--- a/include/matrixFreePDE.h
+++ b/include/matrixFreePDE.h
@@ -346,20 +346,20 @@ protected:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                         &variable_list,
     [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] dealii::VectorizedArray<double>     element_volume) const = 0;
+    [[maybe_unused]] VectorizedArray<double>             element_volume) const = 0;
 
   virtual void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                         &variable_list,
     [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] dealii::VectorizedArray<double>     element_volume) const = 0;
+    [[maybe_unused]] VectorizedArray<double>             element_volume) const = 0;
 
   virtual void
   equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                                   &variable_list,
               [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] dealii::VectorizedArray<double> element_volume) const = 0;
+              [[maybe_unused]] VectorizedArray<double> element_volume) const = 0;
 
   virtual void
   postProcessedFields(
@@ -368,7 +368,7 @@ protected:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] dealii::VectorizedArray<double>           element_volume) const {};
+    [[maybe_unused]] VectorizedArray<double>                   element_volume) const {};
   void
   computePostProcessedFields(std::vector<vectorType *> &postProcessedSet);
 

--- a/src/matrixfree/computeLHS.cc
+++ b/src/matrixfree/computeLHS.cc
@@ -73,6 +73,8 @@ MatrixFreePDE<dim, degree>::getLHS(
 
       unsigned int num_q_points = variable_list.get_num_q_points();
 
+      dealii::VectorizedArray<double> local_element_volume = element_volume[cell];
+
       // loop over quadrature points
       for (unsigned int q = 0; q < num_q_points; ++q)
         {
@@ -82,7 +84,7 @@ MatrixFreePDE<dim, degree>::getLHS(
             variable_list.get_q_point_location();
 
           // Calculate the residuals
-          equationLHS(variable_list, q_point_loc);
+          equationLHS(variable_list, q_point_loc, local_element_volume);
         }
 
       // Integrate the residuals and distribute from local to global

--- a/src/matrixfree/computeRHS.cc
+++ b/src/matrixfree/computeRHS.cc
@@ -44,6 +44,8 @@ MatrixFreePDE<dim, degree>::getExplicitRHS(
 
       unsigned int num_q_points = variable_list.get_num_q_points();
 
+      dealii::VectorizedArray<double> local_element_volume = element_volume[cell];
+
       // loop over quadrature points
       for (unsigned int q = 0; q < num_q_points; ++q)
         {
@@ -53,7 +55,7 @@ MatrixFreePDE<dim, degree>::getExplicitRHS(
             variable_list.get_q_point_location();
 
           // Calculate the residuals
-          explicitEquationRHS(variable_list, q_point_loc);
+          explicitEquationRHS(variable_list, q_point_loc, local_element_volume);
         }
 
       variable_list.integrate_and_distribute(dst);
@@ -101,6 +103,8 @@ MatrixFreePDE<dim, degree>::getNonexplicitRHS(
 
       unsigned int num_q_points = variable_list.get_num_q_points();
 
+      dealii::VectorizedArray<double> local_element_volume = element_volume[cell];
+
       // loop over quadrature points
       for (unsigned int q = 0; q < num_q_points; ++q)
         {
@@ -110,7 +114,7 @@ MatrixFreePDE<dim, degree>::getNonexplicitRHS(
             variable_list.get_q_point_location();
 
           // Calculate the residuals
-          nonExplicitEquationRHS(variable_list, q_point_loc);
+          nonExplicitEquationRHS(variable_list, q_point_loc, local_element_volume);
         }
 
       variable_list.integrate_and_distribute(dst);

--- a/src/matrixfree/init.cc
+++ b/src/matrixfree/init.cc
@@ -370,6 +370,9 @@ MatrixFreePDE<dim, degree>::init()
       load_checkpoint_time_info();
     }
 
+  // Once the initial triangulation has been set, compute element volume
+  compute_element_volume();
+
   computing_timer.leave_subsection("matrixFreePDE: initialization");
 }
 
@@ -405,6 +408,53 @@ MatrixFreePDE<dim, degree>::makeTriangulation(
 
   // Mark boundaries for applying the boundary conditions
   markBoundaries(tria);
+}
+
+template <int dim, int degree>
+void
+MatrixFreePDE<dim, degree>::compute_element_volume()
+{
+  // Get the number of cell batches. Note this is the same as the cell range in
+  // cell_loop()
+  const unsigned int n_cells = matrixFreeObject.n_cell_batches();
+
+  // Resize vector
+  element_volume.resize(n_cells);
+
+  // Set quadrature rule and FEValues to update the JxW values
+  QGaussLobatto<dim> quadrature(degree + 1);
+  FEValues<dim>      fe_values(*(FESet[0]), quadrature, update_JxW_values);
+
+  // Get the number of quadrature points
+  const unsigned int num_quad_points = quadrature.size();
+
+  // Loop over the cells and each lane in the vectorized array
+  for (unsigned int cell = 0; cell < n_cells; cell++)
+    {
+      for (unsigned int lane = 0;
+           lane < matrixFreeObject.n_active_entries_per_cell_batch(cell);
+           lane++)
+        {
+          // Get the iterator for the current cell
+          auto cell_iterator = matrixFreeObject.get_cell_iterator(cell, lane);
+
+          // Reinitialize the cell
+          fe_values.reinit(cell_iterator);
+
+          // Initialize volume to 0 for the current cell
+          double cell_volume = 0.0;
+
+          // Sum up the JxW values at each quadrature point to compute the element volume
+          // in 3D or area in 2D.
+          for (unsigned int q_point = 0; q_point < num_quad_points; ++q_point)
+            {
+              cell_volume += fe_values.JxW(q_point);
+            }
+
+          // Store the element volume
+          element_volume[cell][lane] = cell_volume;
+        }
+    }
 }
 
 #include "../../include/matrixFreePDE_template_instantiations.h"

--- a/src/matrixfree/postprocessor.cc
+++ b/src/matrixfree/postprocessor.cc
@@ -54,6 +54,8 @@ MatrixFreePDE<dim, degree>::getPostProcessedFields(
 
       unsigned int num_q_points = variable_list.get_num_q_points();
 
+      dealii::VectorizedArray<double> local_element_volume = element_volume[cell];
+
       // loop over quadrature points
       for (unsigned int q = 0; q < num_q_points; ++q)
         {
@@ -64,7 +66,10 @@ MatrixFreePDE<dim, degree>::getPostProcessedFields(
             variable_list.get_q_point_location();
 
           // Calculate the residuals
-          postProcessedFields(variable_list, pp_variable_list, q_point_loc);
+          postProcessedFields(variable_list,
+                              pp_variable_list,
+                              q_point_loc,
+                              local_element_volume);
         }
 
       pp_variable_list.integrate_and_distribute(dst);

--- a/src/matrixfree/reinit.cc
+++ b/src/matrixfree/reinit.cc
@@ -205,6 +205,9 @@ MatrixFreePDE<dim, degree>::reinit()
       solutionSet[fieldIndex]->update_ghost_values();
     }
 
+  // Once the initial triangulation has been set, compute element volume
+  compute_element_volume();
+
   computing_timer.leave_subsection("matrixFreePDE: reinitialization");
 }
 

--- a/tests/automatic_tests/CHAC_anisotropyRegularized/customPDE.h
+++ b/tests/automatic_tests/CHAC_anisotropyRegularized/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/tests/automatic_tests/CHAC_anisotropyRegularized/customPDE.h
+++ b/tests/automatic_tests/CHAC_anisotropyRegularized/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/tests/automatic_tests/CHAC_anisotropyRegularized/customPDE.h
+++ b/tests/automatic_tests/CHAC_anisotropyRegularized/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/tests/automatic_tests/CHAC_anisotropyRegularized/equations.cc
+++ b/tests/automatic_tests/CHAC_anisotropyRegularized/equations.cc
@@ -58,7 +58,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -163,7 +164,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -194,5 +196,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/tests/automatic_tests/CHAC_anisotropyRegularized/equations.cc
+++ b/tests/automatic_tests/CHAC_anisotropyRegularized/equations.cc
@@ -59,7 +59,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -165,7 +165,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -197,5 +197,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/tests/automatic_tests/CHAC_anisotropyRegularized/postprocess.cc
+++ b/tests/automatic_tests/CHAC_anisotropyRegularized/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/automatic_tests/CHAC_anisotropyRegularized/postprocess.cc
+++ b/tests/automatic_tests/CHAC_anisotropyRegularized/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/automatic_tests/allenCahn/customPDE.h
+++ b/tests/automatic_tests/allenCahn/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.cc)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.cc)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/tests/automatic_tests/allenCahn/customPDE.h
+++ b/tests/automatic_tests/allenCahn/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/tests/automatic_tests/allenCahn/customPDE.h
+++ b/tests/automatic_tests/allenCahn/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.cc)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.cc)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/tests/automatic_tests/allenCahn/equations.cc
+++ b/tests/automatic_tests/allenCahn/equations.cc
@@ -43,7 +43,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -81,7 +81,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -104,5 +104,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/tests/automatic_tests/allenCahn/equations.cc
+++ b/tests/automatic_tests/allenCahn/equations.cc
@@ -42,7 +42,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -79,7 +80,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -101,5 +103,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/tests/automatic_tests/allenCahn/postprocess.cc
+++ b/tests/automatic_tests/allenCahn/postprocess.cc
@@ -50,7 +50,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/automatic_tests/allenCahn/postprocess.cc
+++ b/tests/automatic_tests/allenCahn/postprocess.cc
@@ -49,7 +49,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/automatic_tests/cahnHilliard/customPDE.h
+++ b/tests/automatic_tests/cahnHilliard/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/tests/automatic_tests/cahnHilliard/customPDE.h
+++ b/tests/automatic_tests/cahnHilliard/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/tests/automatic_tests/cahnHilliard/customPDE.h
+++ b/tests/automatic_tests/cahnHilliard/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/tests/automatic_tests/cahnHilliard/equations.cc
+++ b/tests/automatic_tests/cahnHilliard/equations.cc
@@ -51,7 +51,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
   scalarvalueType c   = variable_list.get_scalar_value(0);
@@ -84,7 +84,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -126,5 +126,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/tests/automatic_tests/cahnHilliard/equations.cc
+++ b/tests/automatic_tests/cahnHilliard/equations.cc
@@ -50,7 +50,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
   scalarvalueType c   = variable_list.get_scalar_value(0);
@@ -82,7 +83,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -123,5 +125,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/tests/automatic_tests/cahnHilliard/postprocess.cc
+++ b/tests/automatic_tests/cahnHilliard/postprocess.cc
@@ -42,7 +42,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/automatic_tests/cahnHilliard/postprocess.cc
+++ b/tests/automatic_tests/cahnHilliard/postprocess.cc
@@ -43,7 +43,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/automatic_tests/coupledCahnHilliardAllenCahn/customPDE.h
+++ b/tests/automatic_tests/coupledCahnHilliardAllenCahn/customPDE.h
@@ -40,7 +40,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -49,14 +49,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -67,7 +68,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/tests/automatic_tests/coupledCahnHilliardAllenCahn/customPDE.h
+++ b/tests/automatic_tests/coupledCahnHilliardAllenCahn/customPDE.h
@@ -38,23 +38,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/tests/automatic_tests/coupledCahnHilliardAllenCahn/customPDE.h
+++ b/tests/automatic_tests/coupledCahnHilliardAllenCahn/customPDE.h
@@ -66,8 +66,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/tests/automatic_tests/coupledCahnHilliardAllenCahn/equations.cc
+++ b/tests/automatic_tests/coupledCahnHilliardAllenCahn/equations.cc
@@ -50,7 +50,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -112,7 +113,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -134,5 +136,6 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {}

--- a/tests/automatic_tests/coupledCahnHilliardAllenCahn/equations.cc
+++ b/tests/automatic_tests/coupledCahnHilliardAllenCahn/equations.cc
@@ -51,7 +51,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -114,7 +114,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}
 
 // =============================================================================================
@@ -137,5 +137,5 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {}

--- a/tests/automatic_tests/coupledCahnHilliardAllenCahn/postprocess.cc
+++ b/tests/automatic_tests/coupledCahnHilliardAllenCahn/postprocess.cc
@@ -50,7 +50,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/automatic_tests/coupledCahnHilliardAllenCahn/postprocess.cc
+++ b/tests/automatic_tests/coupledCahnHilliardAllenCahn/postprocess.cc
@@ -49,7 +49,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/automatic_tests/precipitateEvolution/customPDE.h
+++ b/tests/automatic_tests/precipitateEvolution/customPDE.h
@@ -36,23 +36,25 @@ private:
   void
   explicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS(
-    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                        &variable_list,
-    [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const override;
+  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                                        &variable_list,
+              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS

--- a/tests/automatic_tests/precipitateEvolution/customPDE.h
+++ b/tests/automatic_tests/precipitateEvolution/customPDE.h
@@ -38,7 +38,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
@@ -47,14 +47,15 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
-  equationLHS([[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
-                                                                        &variable_list,
-              [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-              [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+  equationLHS(
+    [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
+                                                              &variable_list,
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 
 // Function to set postprocessing expressions (in postprocess.h)
 #ifdef POSTPROCESS_FILE_EXISTS
@@ -65,7 +66,7 @@ private:
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
     [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
+    [[maybe_unused]] const VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/tests/automatic_tests/precipitateEvolution/customPDE.h
+++ b/tests/automatic_tests/precipitateEvolution/customPDE.h
@@ -64,8 +64,8 @@ private:
       &variable_list,
     [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                               &pp_variable_list,
-    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc)
-    const override;
+    [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+    [[maybe_unused]] VectorizedArray<double> element_volume) const override;
 #endif
 
 // Function to set the nucleation probability (in nucleation.h)

--- a/tests/automatic_tests/precipitateEvolution/equations.cc
+++ b/tests/automatic_tests/precipitateEvolution/equations.cc
@@ -78,7 +78,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -374,7 +375,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -492,7 +494,8 @@ template <int dim, int degree>
 void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
-  [[maybe_unused]] Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
+  [[maybe_unused]] VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/automatic_tests/precipitateEvolution/equations.cc
+++ b/tests/automatic_tests/precipitateEvolution/equations.cc
@@ -79,7 +79,7 @@ void
 customPDE<dim, degree>::explicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -376,7 +376,7 @@ void
 customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 
@@ -495,7 +495,7 @@ void
 customPDE<dim, degree>::equationLHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
-  [[maybe_unused]] VectorizedArray<double> element_volume) const
+  [[maybe_unused]] const VectorizedArray<double> element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/automatic_tests/precipitateEvolution/postprocess.cc
+++ b/tests/automatic_tests/precipitateEvolution/postprocess.cc
@@ -36,7 +36,8 @@ customPDE<dim, degree>::postProcessedFields(
     &variable_list,
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
-  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc) const
+  [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
+  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/automatic_tests/precipitateEvolution/postprocess.cc
+++ b/tests/automatic_tests/precipitateEvolution/postprocess.cc
@@ -37,7 +37,7 @@ customPDE<dim, degree>::postProcessedFields(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>>
                                                             &pp_variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>> q_point_loc,
-  [[maybe_unused]] VectorizedArray<double>                   element_volume) const
+  [[maybe_unused]] const VectorizedArray<double>             element_volume) const
 {
   // --- Getting the values and derivatives of the model variables ---
 

--- a/tests/unit_tests/test_invM.h
+++ b/tests/unit_tests/test_invM.h
@@ -65,20 +65,23 @@ private:
   void
   explicitEquationRHS(
     variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override {};
+    dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc,
+    [[maybe_unused]] dealii::VectorizedArray<double> element_volume) const override {};
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override {};
+    dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc,
+    [[maybe_unused]] dealii::VectorizedArray<double> element_volume) const override {};
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
     variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override {};
+    dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc,
+    [[maybe_unused]] dealii::VectorizedArray<double> element_volume) const override {};
 };
 
 template <int dim, typename T>

--- a/tests/unit_tests/test_setRigidBodyModeConstraints.h
+++ b/tests/unit_tests/test_setRigidBodyModeConstraints.h
@@ -62,20 +62,23 @@ private:
   void
   explicitEquationRHS(
     variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override {};
+    dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc,
+    [[maybe_unused]] dealii::VectorizedArray<double> element_volume) const override {};
 
   // Function to set the RHS of the governing equations for all other equations
   // (in equations.h)
   void
   nonExplicitEquationRHS(
     variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override {};
+    dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc,
+    [[maybe_unused]] dealii::VectorizedArray<double> element_volume) const override {};
 
   // Function to set the LHS of the governing equations (in equations.h)
   void
   equationLHS(
     variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
-    dealii::Point<dim, dealii::VectorizedArray<double>> q_point_loc) const override {};
+    dealii::Point<dim, dealii::VectorizedArray<double>>              q_point_loc,
+    [[maybe_unused]] dealii::VectorizedArray<double> element_volume) const override {};
 };
 
 template <int dim, typename T>


### PR DESCRIPTION
Added a method that compute the element volume and passes it as an input to `equations.cc` and `postprocess.cc` just like the quadrature point location. The volumes are recomputed in `init.cc` and `reinit.cc`.

This can then be used for nucleation, volume-averaged postprocessing, and stabilization schemes like PSPG & SUPG.