### PR TITLE
Adding linux CI timeout

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   CI-Linux:
     runs-on: [ubuntu-22.04]
+    timeout-minutes: 120
 
     container:
       image: dealii/dealii:v9.6.0-jammy
@@ -41,6 +42,7 @@ jobs:
           make -j $(nproc)
 
       - name: Run PRISMS-PF tests
+        timeout-minutes: 60
         run: |
           export OMPI_ALLOW_RUN_AS_ROOT=1
           export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1


### PR DESCRIPTION
There is now a 60 minute time limit in the `run_automatic_tests.py` step and a total time limit of 120 minutes. This works for now, but could be narrowed down in the future. 
Closes #266 