### PR TITLE
Make debug mode run on single thread

### DIFF
--- a/applications/main.cc
+++ b/applications/main.cc
@@ -24,12 +24,19 @@ variableAttributeLoader::loadPostProcessorVariableAttributes()
 #  include <time.h>
 #endif
 
+#ifdef DEBUG
+constexpr unsigned int max_threads_per_process = 1;
+#else
+constexpr unsigned int max_threads_per_process = dealii::numbers::invalid_unsigned_int;
+#endif
+
 // main
 int
 main(int argc, char **argv)
 {
-  dealii::Utilities::MPI::MPI_InitFinalize
-    mpi_initialization(argc, argv, dealii::numbers::invalid_unsigned_int);
+  dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc,
+                                                              argv,
+                                                              max_threads_per_process);
 
   // Parse the command line options (if there are any) to get the name of the
   // input file


### PR DESCRIPTION
Changed main.cc to set the maximum number of threads to 1 when compiled in debug mode.
This makes using visual debuggers much easier .

closes #287 