### PR TITLE
Add label requirement for CI

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,9 +1,6 @@
 name: Clang-Format Check
 
 on: 
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
@@ -17,7 +14,7 @@ permissions:
 
 jobs:
   clang-format-check:
-
+    if: ${{ github.event.label.name == 'Status: Ready to test' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+    types:
+      - labeled
 
 concurrency:
   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,17 +1,9 @@
 name: CI-Linux
 
 on: 
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
     paths-ignore:
       - 'applications/**'
 
@@ -24,6 +16,7 @@ permissions:
 
 jobs:
   CI-Linux:
+    if: ${{ github.event.label.name == 'Status: Ready to test' }}
     runs-on: [ubuntu-22.04]
     timeout-minutes: 120
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+    types:
+      - labeled
     paths-ignore:
       - 'applications/**'
 


### PR DESCRIPTION
CI will only run when a developer add the label, Status: Ready to test. This way there isn't too many extra CI runs.

Closes #316 