### PR TITLE
Update deal.II minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(prisms_pf)
 
@@ -71,7 +71,7 @@ message(STATUS "=========================================================")
 message(STATUS "")
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For detailed instructions on how to download and use PRISMS-PF, please consult t
 
 ### Install:
 
-Install CMake, p4est, and deal.II (version 9.6 recommended).
+Install CMake, p4est, and deal.II (version 9.6.0 or above required).
 
 Clone the PRISMS-PF GitHub repository and navigate its folder.
 ```bash
@@ -98,7 +98,7 @@ following open source applications:
 
 ## Version information:
 
-This version of the code, v2.4, contains moderate changes from v2.3. It was released in November 2024. See [version_changes.md](version_changes.md) for details.
+This version of the code, v3.0, is still under development. See [version_changes.md](version_changes.md) for details of previous releases.
 
 ## License:
 

--- a/applications/CHAC_anisotropy/CMakeLists.txt
+++ b/applications/CHAC_anisotropy/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/CHAC_anisotropyRegularized/CMakeLists.txt
+++ b/applications/CHAC_anisotropyRegularized/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/CHAC_performance_test/CMakeLists.txt
+++ b/applications/CHAC_performance_test/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/MgNd_precipitate_single_Bppp/CMakeLists.txt
+++ b/applications/MgNd_precipitate_single_Bppp/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/allenCahn/CMakeLists.txt
+++ b/applications/allenCahn/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/allenCahn_conserved/CMakeLists.txt
+++ b/applications/allenCahn_conserved/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/alloySolidification/CMakeLists.txt
+++ b/applications/alloySolidification/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/alloySolidification_uniform/CMakeLists.txt
+++ b/applications/alloySolidification_uniform/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/anisotropyFacet/CMakeLists.txt
+++ b/applications/anisotropyFacet/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/cahnHilliard/CMakeLists.txt
+++ b/applications/cahnHilliard/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/corrosion/CMakeLists.txt
+++ b/applications/corrosion/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/corrosion_microgalvanic/CMakeLists.txt
+++ b/applications/corrosion_microgalvanic/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/coupledCahnHilliardAllenCahn/CMakeLists.txt
+++ b/applications/coupledCahnHilliardAllenCahn/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/dendriticSolidification/CMakeLists.txt
+++ b/applications/dendriticSolidification/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/eshelbyInclusion/CMakeLists.txt
+++ b/applications/eshelbyInclusion/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/fickianDiffusion/CMakeLists.txt
+++ b/applications/fickianDiffusion/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/grainGrowth/CMakeLists.txt
+++ b/applications/grainGrowth/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/grainGrowth_dream3d/CMakeLists.txt
+++ b/applications/grainGrowth_dream3d/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/mechanics/CMakeLists.txt
+++ b/applications/mechanics/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/nucleationModel/CMakeLists.txt
+++ b/applications/nucleationModel/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/nucleationModel_preferential/CMakeLists.txt
+++ b/applications/nucleationModel_preferential/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/precipitateEvolution/CMakeLists.txt
+++ b/applications/precipitateEvolution/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/precipitateEvolution_pfunction/CMakeLists.txt
+++ b/applications/precipitateEvolution_pfunction/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/applications/spinodalDecomposition/CMakeLists.txt
+++ b/applications/spinodalDecomposition/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/automatic_tests/CHAC_anisotropyRegularized/CMakeLists.txt
+++ b/automatic_tests/CHAC_anisotropyRegularized/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/automatic_tests/CHiMaD_benchmark6a/CMakeLists.txt
+++ b/automatic_tests/CHiMaD_benchmark6a/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/automatic_tests/allenCahn/CMakeLists.txt
+++ b/automatic_tests/allenCahn/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/automatic_tests/cahnHilliard/CMakeLists.txt
+++ b/automatic_tests/cahnHilliard/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/automatic_tests/corrosion_microgalvanic/CMakeLists.txt
+++ b/automatic_tests/corrosion_microgalvanic/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/automatic_tests/coupledCahnHilliardAllenCahn/CMakeLists.txt
+++ b/automatic_tests/coupledCahnHilliardAllenCahn/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/automatic_tests/grainGrowth/CMakeLists.txt
+++ b/automatic_tests/grainGrowth/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/automatic_tests/precipitateEvolution/CMakeLists.txt
+++ b/automatic_tests/precipitateEvolution/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/automatic_tests/precipitateEvolution_pfunction/CMakeLists.txt
+++ b/automatic_tests/precipitateEvolution_pfunction/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/automatic_tests/spinodalDecomposition/CMakeLists.txt
+++ b/automatic_tests/spinodalDecomposition/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(myapp)
 
@@ -47,7 +47,7 @@ else()
 endif()
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/include/core/matrixFreePDE.h
+++ b/include/core/matrixFreePDE.h
@@ -3,28 +3,26 @@
 #define MATRIXFREEPDE_H
 
 // dealii headers
-#include <deal.II/base/quadrature.h>
-#include <deal.II/base/timer.h>
-#include <deal.II/fe/fe_q.h>
-#include <deal.II/fe/fe_system.h>
-#include <deal.II/fe/fe_values.h>
-#include <deal.II/lac/affine_constraints.h>
-#include <deal.II/lac/vector.h>
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR > 3)
-#  include <deal.II/fe/mapping_fe.h>
-#endif
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/quadrature.h>
+#include <deal.II/base/timer.h>
 #include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_fe.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/manifold_lib.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/vector.h>
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>
 #include <deal.II/numerics/vector_tools.h>

--- a/src/core/boundary_conditions/boundaryConditions.cc
+++ b/src/core/boundary_conditions/boundaryConditions.cc
@@ -273,12 +273,8 @@ MatrixFreePDE<dim, degree>::setPeriodicityConstraints(
                                             periodicity_vector);
         }
     }
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR >= 4)
+
   DoFTools::make_periodicity_constraints<dim, dim>(periodicity_vector, *constraints);
-#else
-  DoFTools::make_periodicity_constraints<DoFHandler<dim>>(periodicity_vector,
-                                                          *constraints);
-#endif
 }
 
 template <int dim, int degree>

--- a/src/core/init.cc
+++ b/src/core/init.cc
@@ -231,31 +231,18 @@ MatrixFreePDE<dim, degree>::init()
 
   // Setup the matrix free object
   typename MatrixFree<dim, double>::AdditionalData additional_data;
-// The member "mpi_communicator" was removed in deal.II version 8.5 but is
-// required before it
-#if (DEAL_II_VERSION_MAJOR < 9 && DEAL_II_VERSION_MINOR < 5)
-  additional_data.mpi_communicator = MPI_COMM_WORLD;
-#endif
   additional_data.tasks_parallel_scheme =
     MatrixFree<dim, double>::AdditionalData::partition_partition;
-  // additional_data.tasks_parallel_scheme =
-  // MatrixFree<dim,double>::AdditionalData::none;
   additional_data.mapping_update_flags =
     (update_values | update_gradients | update_JxW_values | update_quadrature_points);
   QGaussLobatto<1> quadrature(degree + 1);
   matrixFreeObject.clear();
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-  matrixFreeObject.reinit(dofHandlersSet,
-                          constraintsOtherSet,
-                          quadrature,
-                          additional_data);
-#else
   matrixFreeObject.reinit(MappingFE<dim, dim>(FE_Q<dim>(QGaussLobatto<1>(degree + 1))),
                           dofHandlersSet,
                           constraintsOtherSet,
                           quadrature,
                           additional_data);
-#endif
+
   bool dU_scalar_init = false;
   bool dU_vector_init = false;
 

--- a/src/core/initial_conditions/initialConditions.cc
+++ b/src/core/initial_conditions/initialConditions.cc
@@ -260,19 +260,11 @@ MatrixFreePDE<dim, degree>::applyInitialConditions()
                       computeLaplaceRHS(fieldIndex);
                       if (fields[fieldIndex].type == SCALAR)
                         {
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-                          unsigned int invM_size = invMscalar.local_size();
-                          for (unsigned int dof = 0;
-                               dof < solutionSet[fieldIndex]->local_size();
-                               ++dof)
-                            {
-#else
                           unsigned int invM_size = invMscalar.locally_owned_size();
                           for (unsigned int dof = 0;
                                dof < solutionSet[fieldIndex]->locally_owned_size();
                                ++dof)
                             {
-#endif
                               solutionSet[fieldIndex]->local_element(dof) =
                                 solutionSet[fieldIndex]->local_element(dof) -
                                 invMscalar.local_element(dof % invM_size) *
@@ -282,19 +274,11 @@ MatrixFreePDE<dim, degree>::applyInitialConditions()
                         }
                       else if (fields[fieldIndex].type == VECTOR)
                         {
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-                          unsigned int invM_size = invMvector.local_size();
-                          for (unsigned int dof = 0;
-                               dof < solutionSet[fieldIndex]->local_size();
-                               ++dof)
-                            {
-#else
                           unsigned int invM_size = invMvector.locally_owned_size();
                           for (unsigned int dof = 0;
                                dof < solutionSet[fieldIndex]->locally_owned_size();
                                ++dof)
                             {
-#endif
                               solutionSet[fieldIndex]->local_element(dof) =
                                 solutionSet[fieldIndex]->local_element(dof) -
                                 invMvector.local_element(dof % invM_size) *

--- a/src/core/inputFileReader.cc
+++ b/src/core/inputFileReader.cc
@@ -25,11 +25,7 @@ inputFileReader::inputFileReader(const std::string    &input_file_name,
 
   // Read in all of the parameters now
   declare_parameters(parameter_handler, num_constants);
-#if (DEAL_II_VERSION_MAJOR < 9 && DEAL_II_VERSION_MINOR < 5)
-  parameter_handler.read_input(input_file_name);
-#else
   parameter_handler.parse_input(input_file_name);
-#endif
   number_of_dimensions = parameter_handler.get_integer("Number of dimensions");
 }
 

--- a/src/core/invM.cc
+++ b/src/core/invM.cc
@@ -128,13 +128,8 @@ MatrixFreePDE<dim, degree>::computeInvM()
                                            std::multiplies<>());
 
   // Invert scalar mass matrix diagonal elements
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-  for (unsigned int k = 0; k < invMscalar.local_size(); ++k)
-    {
-#else
   for (unsigned int k = 0; k < invMscalar.locally_owned_size(); ++k)
     {
-#endif
       if (std::abs(invMscalar.local_element(k)) > 1.0e-15 * min_cell_volume)
         {
           invMscalar.local_element(k) = 1. / invMscalar.local_element(k);
@@ -148,13 +143,8 @@ MatrixFreePDE<dim, degree>::computeInvM()
         << parabolicScalarFieldIndex << ")\n";
 
   // Invert vector mass matrix diagonal elements
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-  for (unsigned int k = 0; k < invMvector.local_size(); ++k)
-    {
-#else
   for (unsigned int k = 0; k < invMvector.locally_owned_size(); ++k)
     {
-#endif
       if (std::abs(invMvector.local_element(k)) > 1.0e-15 * min_cell_volume)
         {
           invMvector.local_element(k) = 1. / invMvector.local_element(k);

--- a/src/core/outputResults.cc
+++ b/src/core/outputResults.cc
@@ -45,19 +45,11 @@ MatrixFreePDE<dim, degree>::outputResults()
     {
       std::vector<vectorType *> postProcessedSet;
       computePostProcessedFields(postProcessedSet);
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-      unsigned int invM_size = invMscalar.local_size();
-      for (auto &field : postProcessedSet)
-        {
-          for (unsigned int dof = 0; dof < field->local_size(); ++dof)
-            {
-#else
       unsigned int invM_size = invMscalar.locally_owned_size();
       for (auto &field : postProcessedSet)
         {
           for (unsigned int dof = 0; dof < field->locally_owned_size(); ++dof)
             {
-#endif
               field->local_element(dof) =
                 invMscalar.local_element(dof % invM_size) * field->local_element(dof);
             }

--- a/src/core/reinit.cc
+++ b/src/core/reinit.cc
@@ -107,18 +107,12 @@ MatrixFreePDE<dim, degree>::reinit()
     (update_values | update_gradients | update_JxW_values | update_quadrature_points);
   QGaussLobatto<1> quadrature(degree + 1);
   matrixFreeObject.clear();
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-  matrixFreeObject.reinit(dofHandlersSet,
-                          constraintsOtherSet,
-                          quadrature,
-                          additional_data);
-#else
   matrixFreeObject.reinit(MappingFE<dim, dim>(FE_Q<dim>(QGaussLobatto<1>(degree + 1))),
                           dofHandlersSet,
                           constraintsOtherSet,
                           quadrature,
                           additional_data);
-#endif
+
   bool dU_scalar_init = false;
   bool dU_vector_init = false;
 

--- a/src/core/solvers/solveIncrement.cc
+++ b/src/core/solvers/solveIncrement.cc
@@ -261,16 +261,10 @@ MatrixFreePDE<dim, degree>::updateExplicitSolution(unsigned int fieldIndex)
   // is an integer multiple of the length of invM for vector variables
   if (fields[fieldIndex].type == SCALAR)
     {
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-      unsigned int invM_size = invMscalar.local_size();
-      for (unsigned int dof = 0; dof < solutionSet[fieldIndex]->local_size(); ++dof)
-        {
-#else
       unsigned int invM_size = invMscalar.locally_owned_size();
       for (unsigned int dof = 0; dof < solutionSet[fieldIndex]->locally_owned_size();
            ++dof)
         {
-#endif
           solutionSet[fieldIndex]->local_element(dof) =
             invMscalar.local_element(dof % invM_size) *
             residualSet[fieldIndex]->local_element(dof);
@@ -278,16 +272,10 @@ MatrixFreePDE<dim, degree>::updateExplicitSolution(unsigned int fieldIndex)
     }
   else if (fields[fieldIndex].type == VECTOR)
     {
-#if (DEAL_II_VERSION_MAJOR == 9 && DEAL_II_VERSION_MINOR < 4)
-      unsigned int invM_size = invMvector.local_size();
-      for (unsigned int dof = 0; dof < solutionSet[fieldIndex]->local_size(); ++dof)
-        {
-#else
       unsigned int invM_size = invMvector.locally_owned_size();
       for (unsigned int dof = 0; dof < solutionSet[fieldIndex]->locally_owned_size();
            ++dof)
         {
-#endif
           solutionSet[fieldIndex]->local_element(dof) =
             invMvector.local_element(dof % invM_size) *
             residualSet[fieldIndex]->local_element(dof);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@
 #  Adapted from the ASPECT CMake file
 ##
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(prisms_pf_unit_tests)
 
@@ -24,7 +24,7 @@ endif()
 # =========================================================
 
 # Find deal.II installation
-find_package(deal.II 9.2.0 QUIET
+find_package(deal.II 9.6.0 QUIET
 	HINTS ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})


### PR DESCRIPTION
# Description
Dropping support for deal.II versions prior to 9.6.0. The latest versions offers substantial improvements for matrix-free multigrid grid transfer. With the planned implementation for multigrid in PRISMS-PF v3.0 it is worthwhile to change the minimum version of deal.II.

Furthermore, our installation guides are being redone so that should help with installing deal.II 9.6.0 and later.

# Checklist
Miscellaneous items that may need to be done when making a PR:
- [x] Documentation related to this PR is up to date (Doxygen format)
- [x] Unit test(s)
- [x] Code is properly formatted
- [x] Application update script is up to date
- [x] PR labels are applied
- [x] Issues are linked