### PR TITLE
Reorganize inputFileReader and userInputParameters

### DIFF
--- a/include/core/inputFileReader.h
+++ b/include/core/inputFileReader.h
@@ -10,9 +10,9 @@
 #include <string>
 #include <vector>
 
-
 /**
- * \brief Input file reader.
+ * \brief Parameters file reader. Declares parameter names in a dealii parameter_handler
+ * and parses the file for the values. Variable assignment occurs in userInputParameters.
  */
 class inputFileReader
 {
@@ -28,35 +28,23 @@ public:
    * \brief Method to get a list of entry values from multiple subsections in an input
    * file.
    */
-  [[nodiscard]] static std::vector<std::string>
-  get_subsection_entry_list(const std::string &parameters_file_name,
-                            const std::string &subsec_name,
+  [[nodiscard]] std::vector<std::string>
+  get_subsection_entry_list(const std::string &subsec_name,
                             const std::string &entry_name,
                             const std::string &default_entry);
-
-  /**
-   * \brief Method to count the number of related entries in an input file.
-   */
-  [[nodiscard]] static unsigned int
-  get_number_of_entries(const std::string &parameters_file_name,
-                        const std::string &keyword,
-                        const std::string &entry_name);
 
   /**
    * \brief Get the trailing part of the entry name after a specified string (used to
    * extract the model constant names).
    */
-  [[nodiscard]] static std::set<std::string>
-  get_entry_name_ending_list(const std::string &parameters_file_name,
-                             const std::string &keyword,
-                             const std::string &entry_name_begining);
+  [[nodiscard]] std::set<std::string>
+  get_model_constant_names();
 
   /**
    * \brief Method to declare the parameters to be read from an input file.
    */
   void
-  declare_parameters(dealii::ParameterHandler &parameter_handler,
-                     const unsigned int        num_of_constants) const;
+  declare_parameters();
 
   /**
    * \brief Method to check if a line has the desired contents and if so, extract it.
@@ -80,10 +68,82 @@ public:
   static bool
   check_keyword_match(std::string &line, const std::string &keyword);
 
+  /**
+   * \brief Declare parameters for the mesh.
+   */
+  void
+  declare_mesh();
+
+  /**
+   * \brief Declare parameters for timestepping.
+   */
+  void
+  declare_time_discretization();
+
+  /**
+   * \brief Declare parameters for linear and nonlinear solvers.
+   */
+  void
+  declare_solver_parameters();
+
+  /**
+   * \brief Declare parameters for outputs.
+   */
+  void
+  declare_output_parameters();
+
+  /**
+   * \brief Declare parameters for loading ICs from files.
+   */
+  void
+  declare_load_IC_parameters();
+
+  /**
+   * \brief Declare parameters for checkpoints.
+   */
+  void
+  declare_checkpoint_parameters();
+
+  /**
+   * \brief Declare parameters for boundary conditions.
+   */
+  void
+  declare_BC_parameters();
+
+  /**
+   * \brief Declare parameters for pinned points.
+   */
+  void
+  declare_pinning_parameters();
+
+  /**
+   * \brief Declare parameters for nucleation
+   */
+  void
+  declare_nucleation_parameters();
+
+  /**
+   * \brief Declare parameters for grain remapping.
+   */
+  void
+  declare_grain_remapping_parameters();
+
+  /**
+   * \brief Declare parameters for grain structure loading.
+   */
+  void
+  declare_grain_loading_parameters();
+
+  /**
+   * \brief Declare parameters for user-defined model constants.
+   */
+  void
+  declare_model_constants();
+
+  const std::string        parameters_file_name;
   const AttributesList    &var_attributes;
   const AttributesList    &pp_attributes;
   dealii::ParameterHandler parameter_handler;
-  unsigned int             num_constants;
   std::set<std::string>    model_constant_names;
   unsigned int             number_of_dimensions;
 };

--- a/include/core/inputFileReader.h
+++ b/include/core/inputFileReader.h
@@ -6,8 +6,10 @@
 #include <deal.II/base/parameter_handler.h>
 
 #include <core/variableAttributeLoader.h>
+#include <set>
 #include <string>
 #include <vector>
+
 
 /**
  * \brief Input file reader.
@@ -44,7 +46,7 @@ public:
    * \brief Get the trailing part of the entry name after a specified string (used to
    * extract the model constant names).
    */
-  [[nodiscard]] static std::vector<std::string>
+  [[nodiscard]] static std::set<std::string>
   get_entry_name_ending_list(const std::string &parameters_file_name,
                              const std::string &keyword,
                              const std::string &entry_name_begining);
@@ -82,7 +84,7 @@ public:
   const AttributesList    &pp_attributes;
   dealii::ParameterHandler parameter_handler;
   unsigned int             num_constants;
-  std::vector<std::string> model_constant_names;
+  std::set<std::string>    model_constant_names;
   unsigned int             number_of_dimensions;
 };
 

--- a/include/core/userInputParameters.h
+++ b/include/core/userInputParameters.h
@@ -398,8 +398,8 @@ private:
                   const std::vector<unsigned int> &userGivenTimeStepList);
 
   void
-  load_user_constants(inputFileReader          &input_file_reader,
-                      dealii::ParameterHandler &parameter_handler);
+  load_model_constants(inputFileReader          &input_file_reader,
+                       dealii::ParameterHandler &parameter_handler);
 
   /**
    * \brief Compute the number of tensor rows.
@@ -438,7 +438,7 @@ private:
    * \brief Assign the primitive user constants (e.g., int, double, bool).
    */
   InputVariant<dim>
-  primitive_user_constant(std::vector<std::string> &model_constants_strings);
+  primitive_model_constant(std::vector<std::string> &model_constants_strings);
 
   [[nodiscard]] dealii::Tensor<2, 2 * dim - 1 + dim / 3>
   get_Cij_tensor(std::vector<double> elastic_constants,

--- a/include/core/userInputParameters.h
+++ b/include/core/userInputParameters.h
@@ -25,6 +25,14 @@
 #include <unordered_map>
 #include <vector>
 
+template <int dim>
+using InputVariant = boost::variant<double,
+                                    int,
+                                    bool,
+                                    dealii::Tensor<1, dim>,
+                                    dealii::Tensor<2, dim>,
+                                    dealii::Tensor<2, 2 * dim - 1 + dim / 3>>;
+
 enum elasticityModel
 {
   ISOTROPIC,
@@ -59,9 +67,6 @@ public:
   assign_boundary_conditions(std::vector<std::string> &boundary_condition_list,
                              varBCs<dim>              &boundary_condition);
 
-  // Map linking the model constant name to its index
-  std::unordered_map<std::string, unsigned int> model_constant_name_map;
-
   /**
    * \brief Retrieve the double from the `model_constants` that are defined from the
    * parameters.prm parser. This is essentially just a wrapper for boost::get.
@@ -71,13 +76,13 @@ public:
   [[nodiscard]] double
   get_model_constant_double(const std::string &constant_name) const
   {
-    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+    Assert(model_constants.find(constant_name) != model_constants.end(),
            dealii::ExcMessage(
              "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
              "customPDE.h. The constant that you attempted to access was " +
              constant_name + "."));
 
-    return boost::get<double>(model_constants[model_constant_name_map.at(constant_name)]);
+    return boost::get<double>(model_constants.at(constant_name));
   };
 
   /**
@@ -89,13 +94,13 @@ public:
   [[nodiscard]] int
   get_model_constant_int(const std::string &constant_name) const
   {
-    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+    Assert(model_constants.find(constant_name) != model_constants.end(),
            dealii::ExcMessage(
              "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
              "customPDE.h. The constant that you attempted to access was " +
              constant_name + "."));
 
-    return boost::get<int>(model_constants[model_constant_name_map.at(constant_name)]);
+    return boost::get<int>(model_constants.at(constant_name));
   };
 
   /**
@@ -107,13 +112,13 @@ public:
   [[nodiscard]] bool
   get_model_constant_bool(const std::string &constant_name) const
   {
-    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+    Assert(model_constants.find(constant_name) != model_constants.end(),
            dealii::ExcMessage(
              "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
              "customPDE.h. The constant that you attempted to access was " +
              constant_name + "."));
 
-    return boost::get<bool>(model_constants[model_constant_name_map.at(constant_name)]);
+    return boost::get<bool>(model_constants.at(constant_name));
   };
 
   /**
@@ -125,14 +130,13 @@ public:
   [[nodiscard]] dealii::Tensor<1, dim>
   get_model_constant_rank_1_tensor(const std::string &constant_name) const
   {
-    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+    Assert(model_constants.find(constant_name) != model_constants.end(),
            dealii::ExcMessage(
              "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
              "customPDE.h. The constant that you attempted to access was " +
              constant_name + "."));
 
-    return boost::get<dealii::Tensor<1, dim>>(
-      model_constants[model_constant_name_map.at(constant_name)]);
+    return boost::get<dealii::Tensor<1, dim>>(model_constants.at(constant_name));
   };
 
   /**
@@ -144,14 +148,13 @@ public:
   [[nodiscard]] dealii::Tensor<2, dim>
   get_model_constant_rank_2_tensor(const std::string &constant_name) const
   {
-    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+    Assert(model_constants.find(constant_name) != model_constants.end(),
            dealii::ExcMessage(
              "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
              "customPDE.h. The constant that you attempted to access was " +
              constant_name + "."));
 
-    return boost::get<dealii::Tensor<2, dim>>(
-      model_constants[model_constant_name_map.at(constant_name)]);
+    return boost::get<dealii::Tensor<2, dim>>(model_constants.at(constant_name));
   };
 
   /**
@@ -163,14 +166,14 @@ public:
   [[nodiscard]] dealii::Tensor<2, 2 * dim - 1 + dim / 3>
   get_model_constant_elasticity_tensor(const std::string &constant_name) const
   {
-    Assert(model_constant_name_map.find(constant_name) != model_constant_name_map.end(),
+    Assert(model_constants.find(constant_name) != model_constants.end(),
            dealii::ExcMessage(
              "PRISMS-PF Error: Mismatch between constants in parameters.prm and "
              "customPDE.h. The constant that you attempted to access was " +
              constant_name + "."));
 
     return boost::get<dealii::Tensor<2, 2 * dim - 1 + dim / 3>>(
-      model_constants[model_constant_name_map.at(constant_name)]);
+      model_constants.at(constant_name));
   };
 
   // Method to load in the variable attributes
@@ -292,13 +295,7 @@ public:
   std::vector<varBCs<dim>> BC_list;
 
   // List of user-defined constants
-  std::vector<boost::variant<double,
-                             int,
-                             bool,
-                             dealii::Tensor<1, dim>,
-                             dealii::Tensor<2, dim>,
-                             dealii::Tensor<2, 2 * dim - 1 + dim / 3>>>
-    model_constants;
+  std::map<std::string, InputVariant<dim>> model_constants;
 
   // Nucleation parameters
   bool                      nucleation_occurs;
@@ -434,14 +431,14 @@ private:
   /**
    * \brief Assign the specified user constant to whatever type.
    */
-  void
-  assign_user_constant(std::vector<std::string> &model_constants_strings);
+  InputVariant<dim>
+  construct_user_constant(std::vector<std::string> &model_constants_strings);
 
   /**
    * \brief Assign the primitive user constants (e.g., int, double, bool).
    */
-  void
-  assign_primitive_user_constant(std::vector<std::string> &model_constants_strings);
+  InputVariant<dim>
+  primitive_user_constant(std::vector<std::string> &model_constants_strings);
 
   [[nodiscard]] dealii::Tensor<2, 2 * dim - 1 + dim / 3>
   get_Cij_tensor(std::vector<double> elastic_constants,


### PR DESCRIPTION
# Description
Reorganize inputFileReader and userInputParameters.

Mostly reorganization. Split the parameter_handler declarations into several functions rather than one 500-line function.
Object-oriented some functionality. Removed get_number_of_entries.
Renamed a few functions.
Replace vector of model constants with map.

# Checklist
Miscellaneous items that may need to be done when making a PR:
- [x] Documentation related to this PR is up to date (Doxygen format)
- [ ] Unit test(s)
- [x] Code is properly formatted
- [x] PR labels are applied