### PR TITLE
Fixing `CMakeLists.txt` for intel compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(prisms_pf)
-
 file(STRINGS "${CMAKE_SOURCE_DIR}/VERSION" PRISMS_PF_VERSION LIMIT_COUNT 1)
 
 message(STATUS "")
@@ -93,6 +91,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -114,6 +119,16 @@ message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF build targets")
 message(STATUS "=========================================================")
 message(STATUS "")
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(prisms_pf CXX)
+message(STATUS "")
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Generate config.h to enable and disable certain features within the source code.
 set(PRISMS_PF_SOURCE_DIR ${CMAKE_SOURCE_DIR})
@@ -227,6 +242,11 @@ string(REPLACE "-Wno-deprecated-declarations" "" DEAL_II_WARNING_FLAGS "${DEAL_I
 # Set additional compiler flags
 set(PRISMS_PF_ADDITIONAL_CXX_FLAGS "" CACHE STRING "Additional CMAKE_CXX_FLAGS applied after the deal.II options.")
 
+# Add default flags if PRISMS_PF_ADDITIONAL_CXX_FLAGS is empty
+if(PRISMS_PF_ADDITIONAL_CXX_FLAGS STREQUAL "")
+  set(PRISMS_PF_ADDITIONAL_CXX_FLAGS "-Wall -Wextra -Wpedantic -Wunused-variable -Wdisabled-optimization -std=c++17" CACHE STRING "Default CXX flags" FORCE)
+endif()
+
 if(NOT PRISMS_PF_ADDITIONAL_CXX_FLAGS STREQUAL "")
   message(STATUS "Appending PRISMS_PF_ADDITIONAL_CXX_FLAGS: '${PRISMS_PF_ADDITIONAL_CXX_FLAGS}':")
   string(APPEND DEAL_II_CXX_FLAGS_DEBUG " ${PRISMS_PF_ADDITIONAL_CXX_FLAGS}")
@@ -234,6 +254,7 @@ if(NOT PRISMS_PF_ADDITIONAL_CXX_FLAGS STREQUAL "")
   message(STATUS "  DEAL_II_WARNING_FLAGS: ${DEAL_II_WARNING_FLAGS}")
   message(STATUS "  DEAL_II_CXX_FLAGS_DEBUG: ${DEAL_II_CXX_FLAGS_DEBUG}")
   message(STATUS "  DEAL_II_CXX_FLAGS_RELEASE: ${DEAL_II_CXX_FLAGS_RELEASE}")
+  message(STATUS "")
 endif()
 
 if(${PRISMS_PF_BUILD_DEBUG} STREQUAL "ON")

--- a/applications/CHAC_anisotropy/CMakeLists.txt
+++ b/applications/CHAC_anisotropy/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/CHAC_anisotropyRegularized/CMakeLists.txt
+++ b/applications/CHAC_anisotropyRegularized/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/CHAC_performance_test/CMakeLists.txt
+++ b/applications/CHAC_performance_test/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1a/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1b/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark1c/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark2a/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark3a/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6a/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark6b/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/CMakeLists.txt
+++ b/applications/CHiMaD_benchmarks/CHiMaD_benchmark7a/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/MgNd_precipitate_single_Bppp/CMakeLists.txt
+++ b/applications/MgNd_precipitate_single_Bppp/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/allenCahn/CMakeLists.txt
+++ b/applications/allenCahn/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/allenCahn_conserved/CMakeLists.txt
+++ b/applications/allenCahn_conserved/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/alloySolidification/CMakeLists.txt
+++ b/applications/alloySolidification/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/alloySolidification_uniform/CMakeLists.txt
+++ b/applications/alloySolidification_uniform/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/anisotropyFacet/CMakeLists.txt
+++ b/applications/anisotropyFacet/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/cahnHilliard/CMakeLists.txt
+++ b/applications/cahnHilliard/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/corrosion/CMakeLists.txt
+++ b/applications/corrosion/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/corrosion_microgalvanic/CMakeLists.txt
+++ b/applications/corrosion_microgalvanic/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/coupledCahnHilliardAllenCahn/CMakeLists.txt
+++ b/applications/coupledCahnHilliardAllenCahn/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/dendriticSolidification/CMakeLists.txt
+++ b/applications/dendriticSolidification/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/eshelbyInclusion/CMakeLists.txt
+++ b/applications/eshelbyInclusion/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/fickianDiffusion/CMakeLists.txt
+++ b/applications/fickianDiffusion/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/grainGrowth/CMakeLists.txt
+++ b/applications/grainGrowth/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/grainGrowth_dream3d/CMakeLists.txt
+++ b/applications/grainGrowth_dream3d/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/mechanics/CMakeLists.txt
+++ b/applications/mechanics/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/nucleationModel/CMakeLists.txt
+++ b/applications/nucleationModel/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/nucleationModel_preferential/CMakeLists.txt
+++ b/applications/nucleationModel_preferential/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/precipitateEvolution/CMakeLists.txt
+++ b/applications/precipitateEvolution/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/precipitateEvolution_pfunction/CMakeLists.txt
+++ b/applications/precipitateEvolution_pfunction/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/applications/spinodalDecomposition/CMakeLists.txt
+++ b/applications/spinodalDecomposition/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/tests/automatic_tests/CHAC_anisotropyRegularized/CMakeLists.txt
+++ b/tests/automatic_tests/CHAC_anisotropyRegularized/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/tests/automatic_tests/allenCahn/CMakeLists.txt
+++ b/tests/automatic_tests/allenCahn/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/tests/automatic_tests/cahnHilliard/CMakeLists.txt
+++ b/tests/automatic_tests/cahnHilliard/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/tests/automatic_tests/coupledCahnHilliardAllenCahn/CMakeLists.txt
+++ b/tests/automatic_tests/coupledCahnHilliardAllenCahn/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/tests/automatic_tests/precipitateEvolution/CMakeLists.txt
+++ b/tests/automatic_tests/precipitateEvolution/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(myapp)
-
 message(STATUS "")
 message(STATUS "=========================================================")
 message(STATUS "Configuring PRISMS-PF application")
@@ -69,6 +67,13 @@ if(NOT DEAL_II_WITH_P4EST)
     set(DEALII_INSTALL_VALID OFF)
 endif()
 
+if(NOT DEAL_II_WITH_MPI)
+    message(SEND_ERROR
+      "\n**deal.II was built without support for MPI!\n"
+      )
+    set(DEALII_INSTALL_VALID OFF)
+endif()
+
 if(NOT DEALII_INSTALL_VALID)
   message(FATAL_ERROR
     "\nPRISMS-PF requires a deal.II installation with certain features enabled!\n"
@@ -76,6 +81,15 @@ if(NOT DEALII_INSTALL_VALID)
 endif()
 
 deal_ii_initialize_cached_variables()
+
+# Set name of project with deal.II variables loaded in. This lets us find the 
+# right compilers.
+project(myapp CXX)
+
+# Ensure C++17 is used
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Make and ninja build options
 if(CMAKE_GENERATOR MATCHES "Ninja")


### PR DESCRIPTION
# Description
`project()` must be declared after `deal_ii_initialize_cached_variables()` to properly find the mpi compilers.

Closes #373