### PR TITLE
Minimal fix to input file reading

### DIFF
--- a/src/core/initial_conditions/initialConditions.cc
+++ b/src/core/initial_conditions/initialConditions.cc
@@ -315,13 +315,12 @@ MatrixFreePDE<dim, degree>::applyInitialConditions()
   // Read in each vtk once and apply initial conditions
   using ScalarField = PRISMS::PField<double *, double, dim>;
   using Body        = PRISMS::Body<double *, dim>;
-  Body body;
 
-  for (const auto &pair : file_field_map)
+  for (const auto &[filename_no_ext, index_list] : file_field_map)
     {
-      bool                using_parallel_files = false;
-      std::string         filename             = pair.first;
-      std::vector<size_t> index_list           = pair.second;
+      std::string filename = filename_no_ext;
+      Body        body;
+      bool        using_parallel_files = false;
       // For parallel file capability
       for (const auto &index : index_list)
         {


### PR DESCRIPTION
Body contents were not cleared when reading a new file, leading to incorrect behavior when re-using a body object.
(Several other problems are present in IntegrationTools, but they don't seem to be causing immediate issues and may be addressed in v3.0.)