### PR TITLE
Skipping implicit solves in 0th step

### DIFF
--- a/src/solvers/nonexplicit_linear_solver.cc
+++ b/src/solvers/nonexplicit_linear_solver.cc
@@ -116,6 +116,13 @@ nonexplicitLinearSolver<dim, degree>::solve()
 
   for (const auto &[index, variable] : this->subset_attributes)
     {
+      // Skip if the field type is IMPLICIT_TIME_DEPENDENT and the current increment is 0.
+      if (variable.pde_type == PDEType::IMPLICIT_TIME_DEPENDENT &&
+          this->user_inputs->temporal_discretization.get_current_increment() == 0)
+        {
+          continue;
+        }
+
       if (this->user_inputs->linear_solve_parameters.linear_solve.at(index)
             .preconditioner == preconditionerType::GMG)
         {

--- a/src/solvers/nonexplicit_self_nonlinear_solver.cc
+++ b/src/solvers/nonexplicit_self_nonlinear_solver.cc
@@ -117,6 +117,13 @@ nonexplicitSelfNonlinearSolver<dim, degree>::solve()
 
   for (const auto &[index, variable] : this->subset_attributes)
     {
+      // Skip if the field type is IMPLICIT_TIME_DEPENDENT and the current increment is 0.
+      if (variable.pde_type == PDEType::IMPLICIT_TIME_DEPENDENT &&
+          this->user_inputs->temporal_discretization.get_current_increment() == 0)
+        {
+          continue;
+        }
+
       bool         is_converged = true;
       unsigned int iteration    = 0;
       const auto  &step_length =


### PR DESCRIPTION
Previously implicit solves would be solved in the 0th step leading to iterations + 1.