### PR TITLE
make IC  functions members of PDEoperator

### DIFF
--- a/applications/_MgNd_precipitate_single_Bppp/custom_pde.h
+++ b/applications/_MgNd_precipitate_single_Bppp/custom_pde.h
@@ -50,6 +50,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/applications/_precipitate_evolution/ICs_and_BCs.cc
+++ b/applications/_precipitate_evolution/ICs_and_BCs.cc
@@ -13,12 +13,11 @@ PRISMS_PF_BEGIN_NAMESPACE
 template <int dim>
 void
 customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {
   double center[4][3] = {
     {1.0 / 3.0, 1.0 / 3.0, 0.5},

--- a/applications/_precipitate_evolution/custom_pde.h
+++ b/applications/_precipitate_evolution/custom_pde.h
@@ -50,6 +50,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/applications/allen_cahn_explicit/ICs_and_BCs.cc
+++ b/applications/allen_cahn_explicit/ICs_and_BCs.cc
@@ -45,8 +45,10 @@ customPDE<dim, degree, number>::set_initial_condition(
       for (unsigned int dir = 0; dir < dim; dir++)
         {
           dist +=
-            (point[dir] - center[i][dir] * user_inputs.spatial_discretization.size[dir]) *
-            (point[dir] - center[i][dir] * user_inputs.spatial_discretization.size[dir]);
+            (point[dir] -
+             center[i][dir] * this->get_user_inputs().spatial_discretization.size[dir]) *
+            (point[dir] -
+             center[i][dir] * this->get_user_inputs().spatial_discretization.size[dir]);
         }
       dist = std::sqrt(dist);
 

--- a/applications/allen_cahn_explicit/ICs_and_BCs.cc
+++ b/applications/allen_cahn_explicit/ICs_and_BCs.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 PRISMS Center at the University of Michigan
 // SPDX-License-Identifier: GNU Lesser General Public Version 2.1
 
+#include "custom_pde.h"
+
 #include <prismspf/core/initial_conditions.h>
 #include <prismspf/core/nonuniform_dirichlet.h>
 
@@ -12,15 +14,14 @@
 
 PRISMS_PF_BEGIN_NAMESPACE
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree, typename number>
 void
-customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+customPDE<dim, degree, number>::set_initial_condition(
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {
   double center[12][3] = {
     {0.1, 0.3,  0},
@@ -66,15 +67,13 @@ customNonuniformDirichlet<dim, number>::set_nonuniform_dirichlet(
   [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
 {}
 
-template class customInitialCondition<1>;
-template class customInitialCondition<2>;
-template class customInitialCondition<3>;
-
 template class customNonuniformDirichlet<1, double>;
 template class customNonuniformDirichlet<2, double>;
 template class customNonuniformDirichlet<3, double>;
 template class customNonuniformDirichlet<1, float>;
 template class customNonuniformDirichlet<2, float>;
 template class customNonuniformDirichlet<3, float>;
+
+INSTANTIATE_TRI_TEMPLATE(customPDE)
 
 PRISMS_PF_END_NAMESPACE

--- a/applications/allen_cahn_explicit/custom_pde.h
+++ b/applications/allen_cahn_explicit/custom_pde.h
@@ -40,6 +40,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/applications/eshelby_inclusion/ICs_and_BCs.cc
+++ b/applications/eshelby_inclusion/ICs_and_BCs.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 PRISMS Center at the University of Michigan
 // SPDX-License-Identifier: GNU Lesser General Public Version 2.1
 
+#include "custom_pde.h"
+
 #include <prismspf/core/initial_conditions.h>
 #include <prismspf/core/nonuniform_dirichlet.h>
 
@@ -12,15 +14,14 @@
 
 PRISMS_PF_BEGIN_NAMESPACE
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree, typename number>
 void
-customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+customPDE<dim, degree, number>::set_initial_condition(
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {}
 
 template <unsigned int dim, typename number>
@@ -35,15 +36,13 @@ customNonuniformDirichlet<dim, number>::set_nonuniform_dirichlet(
   [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
 {}
 
-template class customInitialCondition<1>;
-template class customInitialCondition<2>;
-template class customInitialCondition<3>;
-
 template class customNonuniformDirichlet<1, double>;
 template class customNonuniformDirichlet<2, double>;
 template class customNonuniformDirichlet<3, double>;
 template class customNonuniformDirichlet<1, float>;
 template class customNonuniformDirichlet<2, float>;
 template class customNonuniformDirichlet<3, float>;
+
+INSTANTIATE_TRI_TEMPLATE(customPDE)
 
 PRISMS_PF_END_NAMESPACE

--- a/applications/eshelby_inclusion/custom_pde.h
+++ b/applications/eshelby_inclusion/custom_pde.h
@@ -40,6 +40,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/include/prismspf/core/initial_conditions.h
+++ b/include/prismspf/core/initial_conditions.h
@@ -7,6 +7,8 @@
 #include <deal.II/base/point.h>
 #include <deal.II/lac/vector.h>
 
+#include <prismspf/core/matrix_free_operator.h>
+#include <prismspf/core/pde_operator.h>
 #include <prismspf/core/type_enums.h>
 
 #include <prismspf/config.h>
@@ -17,26 +19,21 @@ template <unsigned int dim>
 class userInputParameters;
 
 /**
- * \brief Forward declaration of user-facing implementation
- */
-template <unsigned int dim>
-class customInitialCondition;
-
-/**
  * \brief Function for user-implemented initial conditions. These are only ever calculated
  * for explicit time dependent fields and implicit time dependent, as all others are
  * calculated at runtime.
  */
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree>
 class initialCondition : public dealii::Function<dim, double>
 {
 public:
   /**
    * \brief Constructor.
    */
-  initialCondition(const unsigned int             &_index,
-                   const fieldType                &field_type,
-                   const userInputParameters<dim> &_user_inputs);
+  initialCondition(
+    const unsigned int                                            &_index,
+    const fieldType                                               &field_type,
+    const std::shared_ptr<const PDEOperator<dim, degree, double>> &_pde_operator);
 
   // NOLINTBEGIN(readability-identifier-length)
 
@@ -51,34 +48,32 @@ public:
 private:
   unsigned int index;
 
-  const userInputParameters<dim> *user_inputs;
-
-  customInitialCondition<dim> custom_initial_condition;
+  std::shared_ptr<const PDEOperator<dim, degree, double>> pde_operator;
 };
 
-/**
- * \brief User-facing implementation of initial conditions
- */
-template <unsigned int dim>
-class customInitialCondition
-{
-public:
-  /**
-   * \brief Constructor.
-   */
-  customInitialCondition() = default;
-
-  /**
-   * \brief Function that passes the value/vector and point that are set in the initial
-   * condition.
-   */
-  void
-  set_initial_condition(const unsigned int             &index,
-                        const unsigned int             &component,
-                        const dealii::Point<dim>       &point,
-                        double                         &scalar_value,
-                        double                         &vector_component_value,
-                        const userInputParameters<dim> &user_inputs) const;
-};
+///**
+// * \brief User-facing implementation of initial conditions
+// */
+// template <unsigned int dim>
+// class customInitialCondition
+//{
+// public:
+//  /**
+//   * \brief Constructor.
+//   */
+//  customInitialCondition() = default;
+//
+//  /**
+//   * \brief Function that passes the value/vector and point that are set in the initial
+//   * condition.
+//   */
+//  void
+//  set_initial_condition(const unsigned int             &index,
+//                        const unsigned int             &component,
+//                        const dealii::Point<dim>       &point,
+//                        double                         &scalar_value,
+//                        double                         &vector_component_value,
+//                        const userInputParameters<dim> &user_inputs) const;
+//};
 
 PRISMS_PF_END_NAMESPACE

--- a/include/prismspf/core/initial_conditions.h
+++ b/include/prismspf/core/initial_conditions.h
@@ -7,7 +7,6 @@
 #include <deal.II/base/point.h>
 #include <deal.II/lac/vector.h>
 
-#include <prismspf/core/matrix_free_operator.h>
 #include <prismspf/core/pde_operator.h>
 #include <prismspf/core/type_enums.h>
 
@@ -50,30 +49,5 @@ private:
 
   std::shared_ptr<const PDEOperator<dim, degree, double>> pde_operator;
 };
-
-///**
-// * \brief User-facing implementation of initial conditions
-// */
-// template <unsigned int dim>
-// class customInitialCondition
-//{
-// public:
-//  /**
-//   * \brief Constructor.
-//   */
-//  customInitialCondition() = default;
-//
-//  /**
-//   * \brief Function that passes the value/vector and point that are set in the initial
-//   * condition.
-//   */
-//  void
-//  set_initial_condition(const unsigned int             &index,
-//                        const unsigned int             &component,
-//                        const dealii::Point<dim>       &point,
-//                        double                         &scalar_value,
-//                        double                         &vector_component_value,
-//                        const userInputParameters<dim> &user_inputs) const;
-//};
 
 PRISMS_PF_END_NAMESPACE

--- a/include/prismspf/core/pde_operator.h
+++ b/include/prismspf/core/pde_operator.h
@@ -64,6 +64,16 @@ public:
     const dealii::Point<dim, size_type>    &q_point_loc) const = 0;
 
   /**
+   * \brief User-implemented class for the setting initial conditions.
+   */
+  virtual void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const = 0;
+
+  /**
    * \brief Get the user inputs (constant reference).
    */
   [[nodiscard]] const userInputParameters<dim> &

--- a/include/prismspf/solvers/explicit_base.h
+++ b/include/prismspf/solvers/explicit_base.h
@@ -22,7 +22,7 @@ class constraintHandler;
 template <unsigned int dim>
 class dofHandler;
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree>
 class initialCondition;
 
 template <unsigned int dim, unsigned int degree, typename number>

--- a/include/prismspf/solvers/nonexplicit_base.h
+++ b/include/prismspf/solvers/nonexplicit_base.h
@@ -22,7 +22,7 @@ class constraintHandler;
 template <unsigned int dim>
 class dofHandler;
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree>
 class initialCondition;
 
 template <unsigned int dim, unsigned int degree, typename number>

--- a/src/core/initial_conditions.cc
+++ b/src/core/initial_conditions.cc
@@ -14,21 +14,22 @@
 
 PRISMS_PF_BEGIN_NAMESPACE
 
-template <unsigned int dim>
-initialCondition<dim>::initialCondition(const unsigned int             &_index,
-                                        const fieldType                &field_type,
-                                        const userInputParameters<dim> &_user_inputs)
+template <unsigned int dim, unsigned int degree>
+initialCondition<dim, degree>::initialCondition(
+  const unsigned int                                            &_index,
+  const fieldType                                               &field_type,
+  const std::shared_ptr<const PDEOperator<dim, degree, double>> &_pde_operator)
   : dealii::Function<dim>((field_type == fieldType::VECTOR) ? dim : 1)
   , index(_index)
-  , user_inputs(&_user_inputs)
+  , pde_operator(_pde_operator)
 {}
 
 // NOLINTBEGIN(readability-identifier-length)
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree>
 void
-initialCondition<dim>::vector_value(const dealii::Point<dim> &p,
-                                    dealii::Vector<double>   &value) const
+initialCondition<dim, degree>::vector_value(const dealii::Point<dim> &p,
+                                            dealii::Vector<double>   &value) const
 {
   // Initialize passed variables to zero
   dealii::Vector<double> vector_value(dim);
@@ -36,12 +37,7 @@ initialCondition<dim>::vector_value(const dealii::Point<dim> &p,
   // Pass variables to user-facing function to evaluate
   for (unsigned int i = 0; i < dim; i++)
     {
-      custom_initial_condition.set_initial_condition(index,
-                                                     i,
-                                                     p,
-                                                     vector_value(0),
-                                                     vector_value(i),
-                                                     *user_inputs);
+      pde_operator->set_initial_condition(index, i, p, vector_value(0), vector_value(i));
     }
 
   value = vector_value;
@@ -49,6 +45,6 @@ initialCondition<dim>::vector_value(const dealii::Point<dim> &p,
 
 // NOLINTEND(readability-identifier-length)
 
-INSTANTIATE_UNI_TEMPLATE(initialCondition)
+INSTANTIATE_BI_TEMPLATE(initialCondition)
 
 PRISMS_PF_END_NAMESPACE

--- a/src/core/initial_conditions.cc
+++ b/src/core/initial_conditions.cc
@@ -37,7 +37,7 @@ initialCondition<dim, degree>::vector_value(const dealii::Point<dim> &p,
   // Pass variables to user-facing function to evaluate
   for (unsigned int i = 0; i < dim; i++)
     {
-      pde_operator->set_initial_condition(index, i, p, vector_value(0), vector_value(i));
+      pde_operator->set_initial_condition(index, i, p, vector_value[0], vector_value[i]);
     }
 
   value = vector_value;

--- a/src/solvers/explicit_base.cc
+++ b/src/solvers/explicit_base.cc
@@ -134,9 +134,9 @@ explicitBase<dim, degree>::set_initial_condition()
       dealii::VectorTools::interpolate(
         *mapping,
         *(dof_handler->get_dof_handlers().at(index)),
-        initialCondition<dim>(index,
-                              subset_attributes.at(index).field_type,
-                              *user_inputs),
+        initialCondition<dim, degree>(index,
+                                      subset_attributes.at(index).field_type,
+                                      pde_operator),
         *(solution_handler->get_solution_vector(index, dependencyType::NORMAL)));
     }
 }

--- a/src/solvers/nonexplicit_base.cc
+++ b/src/solvers/nonexplicit_base.cc
@@ -153,9 +153,9 @@ nonexplicitBase<dim, degree>::set_initial_condition()
       dealii::VectorTools::interpolate(
         *mapping,
         *(dof_handler->get_dof_handlers().at(index)),
-        initialCondition<dim>(index,
-                              subset_attributes.at(index).field_type,
-                              *user_inputs),
+        initialCondition<dim, degree>(index,
+                                      subset_attributes.at(index).field_type,
+                                      pde_operator),
         *(solution_handler->get_solution_vector(index, dependencyType::NORMAL)));
 
       // TODO (landinjm): Fix so that we apply some sort of initial condition to all old

--- a/tests/automatic_tests/allen_cahn_explicit/ICs_and_BCs.cc
+++ b/tests/automatic_tests/allen_cahn_explicit/ICs_and_BCs.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 PRISMS Center at the University of Michigan
 // SPDX-License-Identifier: GNU Lesser General Public Version 2.1
 
+#include "custom_pde.h"
+
 #include <prismspf/core/initial_conditions.h>
 #include <prismspf/core/nonuniform_dirichlet.h>
 
@@ -14,15 +16,14 @@
 
 PRISMS_PF_BEGIN_NAMESPACE
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree, typename number>
 void
-customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+customPDE<dim, degree, number>::set_initial_condition(
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {
   double center[12][3] = {
     {0.1, 0.3,  0},
@@ -67,15 +68,13 @@ customNonuniformDirichlet<dim, number>::set_nonuniform_dirichlet(
   [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
 {}
 
-template class customInitialCondition<1>;
-template class customInitialCondition<2>;
-template class customInitialCondition<3>;
-
 template class customNonuniformDirichlet<1, double>;
 template class customNonuniformDirichlet<2, double>;
 template class customNonuniformDirichlet<3, double>;
 template class customNonuniformDirichlet<1, float>;
 template class customNonuniformDirichlet<2, float>;
 template class customNonuniformDirichlet<3, float>;
+
+INSTANTIATE_TRI_TEMPLATE(customPDE)
 
 PRISMS_PF_END_NAMESPACE

--- a/tests/automatic_tests/allen_cahn_explicit/custom_pde.h
+++ b/tests/automatic_tests/allen_cahn_explicit/custom_pde.h
@@ -42,6 +42,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/tests/automatic_tests/allen_cahn_implicit/ICs_and_BCs.cc
+++ b/tests/automatic_tests/allen_cahn_implicit/ICs_and_BCs.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 PRISMS Center at the University of Michigan
 // SPDX-License-Identifier: GNU Lesser General Public Version 2.1
 
+#include "custom_pde.h"
+
 #include <prismspf/core/initial_conditions.h>
 #include <prismspf/core/nonuniform_dirichlet.h>
 
@@ -14,15 +16,14 @@
 
 PRISMS_PF_BEGIN_NAMESPACE
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree, typename number>
 void
-customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+customPDE<dim, degree, number>::set_initial_condition(
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {
   double center[12][3] = {
     {0.1, 0.3,  0},
@@ -67,15 +68,13 @@ customNonuniformDirichlet<dim, number>::set_nonuniform_dirichlet(
   [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
 {}
 
-template class customInitialCondition<1>;
-template class customInitialCondition<2>;
-template class customInitialCondition<3>;
-
 template class customNonuniformDirichlet<1, double>;
 template class customNonuniformDirichlet<2, double>;
 template class customNonuniformDirichlet<3, double>;
 template class customNonuniformDirichlet<1, float>;
 template class customNonuniformDirichlet<2, float>;
 template class customNonuniformDirichlet<3, float>;
+
+INSTANTIATE_TRI_TEMPLATE(customPDE)
 
 PRISMS_PF_END_NAMESPACE

--- a/tests/automatic_tests/allen_cahn_implicit/custom_pde.h
+++ b/tests/automatic_tests/allen_cahn_implicit/custom_pde.h
@@ -42,6 +42,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/tests/automatic_tests/blank/ICs_and_BCs.cc
+++ b/tests/automatic_tests/blank/ICs_and_BCs.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 PRISMS Center at the University of Michigan
 // SPDX-License-Identifier: GNU Lesser General Public Version 2.1
 
+#include "custom_pde.h"
+
 #include <prismspf/core/initial_conditions.h>
 #include <prismspf/core/nonuniform_dirichlet.h>
 
@@ -14,15 +16,14 @@
 
 PRISMS_PF_BEGIN_NAMESPACE
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree, typename number>
 void
-customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+customPDE<dim, degree, number>::set_initial_condition(
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {}
 
 template <unsigned int dim, typename number>
@@ -37,15 +38,13 @@ customNonuniformDirichlet<dim, number>::set_nonuniform_dirichlet(
   [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
 {}
 
-template class customInitialCondition<1>;
-template class customInitialCondition<2>;
-template class customInitialCondition<3>;
-
 template class customNonuniformDirichlet<1, double>;
 template class customNonuniformDirichlet<2, double>;
 template class customNonuniformDirichlet<3, double>;
 template class customNonuniformDirichlet<1, float>;
 template class customNonuniformDirichlet<2, float>;
 template class customNonuniformDirichlet<3, float>;
+
+INSTANTIATE_TRI_TEMPLATE(customPDE)
 
 PRISMS_PF_END_NAMESPACE

--- a/tests/automatic_tests/blank/custom_pde.h
+++ b/tests/automatic_tests/blank/custom_pde.h
@@ -42,6 +42,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/tests/automatic_tests/cahn_hilliard_explicit/ICs_and_BCs.cc
+++ b/tests/automatic_tests/cahn_hilliard_explicit/ICs_and_BCs.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 PRISMS Center at the University of Michigan
 // SPDX-License-Identifier: GNU Lesser General Public Version 2.1
 
+#include "custom_pde.h"
+
 #include <prismspf/core/initial_conditions.h>
 #include <prismspf/core/nonuniform_dirichlet.h>
 
@@ -15,15 +17,14 @@
 
 PRISMS_PF_BEGIN_NAMESPACE
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree, typename number>
 void
-customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+customPDE<dim, degree, number>::set_initial_condition(
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {
   if (index == 0)
     {
@@ -71,15 +72,13 @@ customNonuniformDirichlet<dim, number>::set_nonuniform_dirichlet(
   [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
 {}
 
-template class customInitialCondition<1>;
-template class customInitialCondition<2>;
-template class customInitialCondition<3>;
-
 template class customNonuniformDirichlet<1, double>;
 template class customNonuniformDirichlet<2, double>;
 template class customNonuniformDirichlet<3, double>;
 template class customNonuniformDirichlet<1, float>;
 template class customNonuniformDirichlet<2, float>;
 template class customNonuniformDirichlet<3, float>;
+
+INSTANTIATE_TRI_TEMPLATE(customPDE)
 
 PRISMS_PF_END_NAMESPACE

--- a/tests/automatic_tests/cahn_hilliard_explicit/custom_pde.h
+++ b/tests/automatic_tests/cahn_hilliard_explicit/custom_pde.h
@@ -42,6 +42,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/tests/automatic_tests/fracture/ICs_and_BCs.cc
+++ b/tests/automatic_tests/fracture/ICs_and_BCs.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 PRISMS Center at the University of Michigan
 // SPDX-License-Identifier: GNU Lesser General Public Version 2.1
 
+#include "custom_pde.h"
+
 #include <prismspf/core/initial_conditions.h>
 #include <prismspf/core/nonuniform_dirichlet.h>
 
@@ -11,26 +13,25 @@
 #include <prismspf/config.h>
 
 #include <cmath>
-#include <numbers>
 
 PRISMS_PF_BEGIN_NAMESPACE
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree, typename number>
 void
-customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+customPDE<dim, degree, number>::set_initial_condition(
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {
   const double center[3] = {10.0, 12.0, 0.0};
-  const double dx        = user_inputs.spatial_discretization.size[0] /
-                    double(user_inputs.spatial_discretization.subdivisions[0]) /
-                    std::pow(2.0, user_inputs.spatial_discretization.global_refinement);
+  const double dx =
+    this->get_user_inputs().spatial_discretization.size[0] /
+    double(this->get_user_inputs().spatial_discretization.subdivisions[0]) /
+    std::pow(2.0, this->get_user_inputs().spatial_discretization.global_refinement);
   const double clength =
-    user_inputs.user_constants.get_model_constant_double("cracklength");
+    this->get_user_inputs().user_constants.get_model_constant_double("cracklength");
 
   double dist = 0.0;
   for (unsigned int dir = 0; dir < dim; dir++)
@@ -44,7 +45,8 @@ customInitialCondition<dim>::set_initial_condition(
 
   if (index == 0)
     {
-      if ((std::abs(point[1] - (user_inputs.spatial_discretization.size[1] / 2.0) +
+      if ((std::abs(point[1] -
+                    (this->get_user_inputs().spatial_discretization.size[1] / 2.0) +
                     (0.5 * dx)) < dx) &&
           (point[0] < clength))
         {
@@ -110,15 +112,13 @@ customNonuniformDirichlet<dim, number>::set_nonuniform_dirichlet(
     }
 }
 
-template class customInitialCondition<1>;
-template class customInitialCondition<2>;
-template class customInitialCondition<3>;
-
 template class customNonuniformDirichlet<1, double>;
 template class customNonuniformDirichlet<2, double>;
 template class customNonuniformDirichlet<3, double>;
 template class customNonuniformDirichlet<1, float>;
 template class customNonuniformDirichlet<2, float>;
 template class customNonuniformDirichlet<3, float>;
+
+INSTANTIATE_TRI_TEMPLATE(customPDE)
 
 PRISMS_PF_END_NAMESPACE

--- a/tests/automatic_tests/fracture/custom_pde.h
+++ b/tests/automatic_tests/fracture/custom_pde.h
@@ -40,6 +40,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/tests/automatic_tests/heat_equation_steady_state/ICs_and_BCs.cc
+++ b/tests/automatic_tests/heat_equation_steady_state/ICs_and_BCs.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 PRISMS Center at the University of Michigan
 // SPDX-License-Identifier: GNU Lesser General Public Version 2.1
 
+#include "custom_pde.h"
+
 #include <prismspf/core/initial_conditions.h>
 #include <prismspf/core/nonuniform_dirichlet.h>
 
@@ -14,15 +16,14 @@
 
 PRISMS_PF_BEGIN_NAMESPACE
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree, typename number>
 void
-customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+customPDE<dim, degree, number>::set_initial_condition(
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {
   if (index == 1)
     {
@@ -47,15 +48,13 @@ customNonuniformDirichlet<dim, number>::set_nonuniform_dirichlet(
   [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
 {}
 
-template class customInitialCondition<1>;
-template class customInitialCondition<2>;
-template class customInitialCondition<3>;
-
 template class customNonuniformDirichlet<1, double>;
 template class customNonuniformDirichlet<2, double>;
 template class customNonuniformDirichlet<3, double>;
 template class customNonuniformDirichlet<1, float>;
 template class customNonuniformDirichlet<2, float>;
 template class customNonuniformDirichlet<3, float>;
+
+INSTANTIATE_TRI_TEMPLATE(customPDE)
 
 PRISMS_PF_END_NAMESPACE

--- a/tests/automatic_tests/heat_equation_steady_state/custom_pde.h
+++ b/tests/automatic_tests/heat_equation_steady_state/custom_pde.h
@@ -42,6 +42,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/tests/automatic_tests/mechanics/ICs_and_BCs.cc
+++ b/tests/automatic_tests/mechanics/ICs_and_BCs.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 PRISMS Center at the University of Michigan
 // SPDX-License-Identifier: GNU Lesser General Public Version 2.1
 
+#include "custom_pde.h"
+
 #include <prismspf/core/initial_conditions.h>
 #include <prismspf/core/nonuniform_dirichlet.h>
 
@@ -14,15 +16,14 @@
 
 PRISMS_PF_BEGIN_NAMESPACE
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree, typename number>
 void
-customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+customPDE<dim, degree, number>::set_initial_condition(
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {}
 
 template <unsigned int dim, typename number>
@@ -37,15 +38,13 @@ customNonuniformDirichlet<dim, number>::set_nonuniform_dirichlet(
   [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
 {}
 
-template class customInitialCondition<1>;
-template class customInitialCondition<2>;
-template class customInitialCondition<3>;
-
 template class customNonuniformDirichlet<1, double>;
 template class customNonuniformDirichlet<2, double>;
 template class customNonuniformDirichlet<3, double>;
 template class customNonuniformDirichlet<1, float>;
 template class customNonuniformDirichlet<2, float>;
 template class customNonuniformDirichlet<3, float>;
+
+INSTANTIATE_TRI_TEMPLATE(customPDE)
 
 PRISMS_PF_END_NAMESPACE

--- a/tests/automatic_tests/mechanics/custom_pde.h
+++ b/tests/automatic_tests/mechanics/custom_pde.h
@@ -42,6 +42,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/tests/automatic_tests/precipitate_explicit/ICs_and_BCs.cc
+++ b/tests/automatic_tests/precipitate_explicit/ICs_and_BCs.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 PRISMS Center at the University of Michigan
 // SPDX-License-Identifier: GNU Lesser General Public Version 2.1
 
+#include "custom_pde.h"
+
 #include <prismspf/core/initial_conditions.h>
 #include <prismspf/core/nonuniform_dirichlet.h>
 
@@ -14,15 +16,14 @@
 
 PRISMS_PF_BEGIN_NAMESPACE
 
-template <unsigned int dim>
+template <unsigned int dim, unsigned int degree, typename number>
 void
-customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+customPDE<dim, degree, number>::set_initial_condition(
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {
   const double x_length           = user_inputs.spatial_discretization.size[0];
   const double refinement         = user_inputs.spatial_discretization.global_refinement;
@@ -83,15 +84,13 @@ customNonuniformDirichlet<dim, number>::set_nonuniform_dirichlet(
   [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
 {}
 
-template class customInitialCondition<1>;
-template class customInitialCondition<2>;
-template class customInitialCondition<3>;
-
 template class customNonuniformDirichlet<1, double>;
 template class customNonuniformDirichlet<2, double>;
 template class customNonuniformDirichlet<3, double>;
 template class customNonuniformDirichlet<1, float>;
 template class customNonuniformDirichlet<2, float>;
 template class customNonuniformDirichlet<3, float>;
+
+INSTANTIATE_TRI_TEMPLATE(customPDE)
 
 PRISMS_PF_END_NAMESPACE

--- a/tests/automatic_tests/precipitate_explicit/ICs_and_BCs.cc
+++ b/tests/automatic_tests/precipitate_explicit/ICs_and_BCs.cc
@@ -25,8 +25,9 @@ customPDE<dim, degree, number>::set_initial_condition(
   [[maybe_unused]] double                   &scalar_value,
   [[maybe_unused]] double                   &vector_component_value) const
 {
-  const double x_length           = user_inputs.spatial_discretization.size[0];
-  const double refinement         = user_inputs.spatial_discretization.global_refinement;
+  const double x_length = this->get_user_inputs().spatial_discretization.size[0];
+  const double refinement =
+    this->get_user_inputs().spatial_discretization.global_refinement;
   const double radius_size_factor = 16.0;
   const double concentration      = 0.04;
 

--- a/tests/automatic_tests/precipitate_explicit/custom_pde.h
+++ b/tests/automatic_tests/precipitate_explicit/custom_pde.h
@@ -42,6 +42,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void

--- a/tests/performance_tests/allen_cahn/custom_pde.h
+++ b/tests/performance_tests/allen_cahn/custom_pde.h
@@ -61,6 +61,16 @@ public:
 
 private:
   /**
+   * \brief User-implemented class for the initial conditions.
+   */
+  void
+  set_initial_condition(const unsigned int       &index,
+                        const unsigned int       &component,
+                        const dealii::Point<dim> &point,
+                        double                   &scalar_value,
+                        double                   &vector_component_value) const override;
+
+  /**
    * \brief User-implemented class for the RHS of explicit equations.
    */
   void
@@ -113,12 +123,11 @@ customAttributeLoader::loadVariableAttributes()
 template <unsigned int dim>
 inline void
 customInitialCondition<dim>::set_initial_condition(
-  [[maybe_unused]] const unsigned int             &index,
-  [[maybe_unused]] const unsigned int             &component,
-  [[maybe_unused]] const dealii::Point<dim>       &point,
-  [[maybe_unused]] double                         &scalar_value,
-  [[maybe_unused]] double                         &vector_component_value,
-  [[maybe_unused]] const userInputParameters<dim> &user_inputs) const
+  [[maybe_unused]] const unsigned int       &index,
+  [[maybe_unused]] const unsigned int       &component,
+  [[maybe_unused]] const dealii::Point<dim> &point,
+  [[maybe_unused]] double                   &scalar_value,
+  [[maybe_unused]] double                   &vector_component_value) const
 {
   double center[12][3] = {
     {0.1, 0.3,  0},


### PR DESCRIPTION
# Description

These were moved out because of issues in the past, but bringing them back can eliminate code duplication by giving access to custom members of the derived pde class.