### PR TITLE
Remove quotes from reference to userInputs.output_file_type

### DIFF
--- a/src/core/outputResults.cc
+++ b/src/core/outputResults.cc
@@ -177,7 +177,7 @@ MatrixFreePDE<dim, degree>::outputResults()
                   std::ostringstream vtuProcFileNameStream;
                   vtuProcFileNameStream << userInputs.output_file_name << "-"
                                         << cycleAsString.str() << "." << i << "."
-                                        << "userInputs.output_file_type";
+                                        << userInputs.output_file_type;
                   std::string vtuProcFileName = vtuProcFileNameStream.str();
 
                   filenames.emplace_back(vtuProcFileName);


### PR DESCRIPTION
Simple fix: the output file type, userInputs.output_file_type, was being printed as a string literal when it should have been a reference to a variable. This change correctly results in .pvtu output files with, e.g., Piece <Piece Source="solution-000.0.vtu"/> instead of <Piece Source="solution-000.0.userInputs.output_file_type"/>