### PR TITLE
add lower bound for rectangular doamins

### DIFF
--- a/include/prismspf/user_inputs/spatial_discretization.h
+++ b/include/prismspf/user_inputs/spatial_discretization.h
@@ -635,9 +635,43 @@ public:
     return type;
   }
 
+  /**
+   * @brief Set the lower bound in each cartesian direction
+   */
+  void
+  set_lower_bound(const unsigned int &direction, const double &_lower_bound)
+  {
+    lower_bound[direction] = _lower_bound;
+  }
+
+  /**
+   * @brief Get the lower bound for the rectangular grid
+   */
+  [[nodiscard]] const dealii::Point<dim, double> &
+  get_lower_bound() const
+  {
+    return lower_bound;
+  }
+
+  /**
+   * @brief Get the upper bound for the rectangular grid
+   */
+  [[nodiscard]] const dealii::Point<dim, double> &
+  get_upper_bound() const
+  {
+    upper_bound = dealii::Point<dim>(size) + lower_bound;
+    return upper_bound;
+  }
+
 private:
   // Triangulation type
   TriangulationType type = TriangulationType::Rectangular;
+
+  // Domain lower bound for rectangular domains
+  dealii::Point<dim, double> lower_bound;
+
+  // Domain upper bound for rectangular domains
+  mutable dealii::Point<dim, double> upper_bound;
 
   // Domain extents in each cartesian direction
   dealii::Tensor<1, dim, double> size;

--- a/src/core/triangulation_handler.cc
+++ b/src/core/triangulation_handler.cc
@@ -131,8 +131,8 @@ TriangulationHandler<dim>::generate_mesh()
       dealii::GridGenerator::subdivided_hyper_rectangle(
         *triangulation,
         user_inputs->get_spatial_discretization().get_subdivisions(),
-        dealii::Point<dim>(),
-        dealii::Point<dim>(user_inputs->get_spatial_discretization().get_size()));
+        user_inputs->get_spatial_discretization().get_lower_bound(),
+        user_inputs->get_spatial_discretization().get_upper_bound());
 
       // Mark boundaries. This is done before global refinement to reduce the number of
       // cells we have to loop through.
@@ -206,11 +206,16 @@ TriangulationHandler<dim>::mark_boundaries() const
           // Direction for quad and hex cells
           auto direction = static_cast<unsigned int>(std::floor(face_number / 2));
 
-          // Mark the boundary id for x=0, y=0, z=0 and x=max, y=max, z=max
-          if (std::fabs(cell->face(face_number)->center()(direction) - 0) < tolerance ||
-              std::fabs(
-                cell->face(face_number)->center()(direction) -
-                (user_inputs->get_spatial_discretization().get_size()[direction])) <
+          // Lower bound and upper bound
+          const double lower_bound =
+            user_inputs->get_spatial_discretization().get_lower_bound()[direction];
+          const double upper_bound =
+            user_inputs->get_spatial_discretization().get_upper_bound()[direction];
+
+          // Mark the boundary id for lower and upper bounds
+          if (std::fabs(cell->face(face_number)->center()(direction) - lower_bound) <
+                tolerance ||
+              std::fabs(cell->face(face_number)->center()(direction) - upper_bound) <
                 tolerance)
             {
               cell->face(face_number)->set_boundary_id(face_number);

--- a/src/user_inputs/input_file_reader.cc
+++ b/src/user_inputs/input_file_reader.cc
@@ -251,6 +251,18 @@ InputFileReader::declare_mesh()
                                     "0.0",
                                     dealii::Patterns::Double(0.0, DBL_MAX),
                                     "The size of the domain in the z direction.");
+    parameter_handler.declare_entry("x lower bound",
+                                    "0.0",
+                                    dealii::Patterns::Double(-DBL_MAX, DBL_MAX),
+                                    "The lower bound of the domain in the x direction.");
+    parameter_handler.declare_entry("y lower bound",
+                                    "0.0",
+                                    dealii::Patterns::Double(-DBL_MAX, DBL_MAX),
+                                    "The lower bound of the domain in the y direction.");
+    parameter_handler.declare_entry("z lower bound",
+                                    "0.0",
+                                    dealii::Patterns::Double(-DBL_MAX, DBL_MAX),
+                                    "The lower bound of the domain in the z direction.");
     parameter_handler.declare_entry(
       "x subdivisions",
       "1",

--- a/src/user_inputs/user_input_parameters.cc
+++ b/src/user_inputs/user_input_parameters.cc
@@ -85,6 +85,9 @@ UserInputParameters<dim>::assign_spatial_discretization_parameters(
         spatial_discretization.set_size(i,
                                         parameter_handler.get_double(axis_labels[i] +
                                                                      " size"));
+        spatial_discretization.set_lower_bound(i,
+                                               parameter_handler.get_double(
+                                                 axis_labels[i] + " lower bound"));
         spatial_discretization.set_subdivisions(i,
                                                 static_cast<unsigned int>(
                                                   parameter_handler.get_integer(


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The PR follows our guidelines (formatting & style)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add lower bound to rectangular domains. Closes #748. 


* **What is the current behavior?** (You can also link to an open issue here)
Currently, the lower bound of the domain defaults to the origin.


* **What is the new behavior (if this is a feature change)?**
The user can now specify the lower bound of the domain, avoiding shifting equations.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
