### PR TITLE
Fix race condition in parallel build (Fix #722)

### DIFF
--- a/cmake/macros/macro_prisms_pf_autopilot.cmake
+++ b/cmake/macros/macro_prisms_pf_autopilot.cmake
@@ -40,6 +40,8 @@ macro(prisms_pf_autopilot PRISMS_PF_CORE_DIR)
 
     add_executable(${_target} ${TARGET_SRC})
 
+    add_dependencies(${_target} dummy_inst)
+
     if(TARGET prisms_pf::prisms_pf_${_build_lowercase})
       target_link_libraries(${_target} PRIVATE prisms_pf::prisms_pf_${_build_lowercase})
       message(STATUS "Successfully linked ${_target} to prisms_pf_${_build_lowercase}")


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The PR follows our guidelines (formatting & style)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix #722

I put template_instantiations outside of the for loop, sine it is the same for all targets.

* **What is the current behavior?** (You can also link to an open issue here)
Old code has racing issue when build with multiple cores.


* **What is the new behavior (if this is a feature change)?**
build applications with multiple cores without issue


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
NA
