### PR TITLE
Upgrades to timer

### DIFF
--- a/include/prismspf/core/pde_problem.h
+++ b/include/prismspf/core/pde_problem.h
@@ -9,6 +9,7 @@
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_q1.h>
 
+#include <prismspf/core/timer.h>
 #include <prismspf/core/types.h>
 #include <prismspf/core/vector_mapping.h>
 
@@ -112,6 +113,11 @@ private:
    */
   void
   reinit_system();
+
+  /**
+   * @brief Timer instance for the class.
+   */
+  Timer::Scope timer_scope;
 
   /**
    * @brief User-inputs.

--- a/include/prismspf/core/timer.h
+++ b/include/prismspf/core/timer.h
@@ -25,7 +25,65 @@ public:
   /**
    * @brief Constructor.
    */
-  Timer();
+  Timer() = default;
+
+  /**
+   * @brief Destructor.
+   *
+   * Calls `print_summary` upon destruction.
+   */
+  ~Timer();
+
+  Timer(const Timer &) = delete;
+  Timer &
+  operator=(const Timer &) = delete;
+  Timer(Timer &&)          = delete;
+  Timer &
+  operator=(Timer &&) = delete;
+
+  /**
+   * @brief Timer scope guard.
+   *
+   * This allows you to use the timer like the following
+   * @code
+   * void f()
+   * {
+   *  Timer::Scope outer("outer");
+   *
+   *  {
+   *    Timer::Scope inner("inner");
+   *    // Work goes here
+   *  } // Inner scope ends here
+   *
+   * // Work goes here
+   * } // Outer scope ends here
+   * @endcode
+   *
+   */
+  struct Scope
+  {
+  public:
+    explicit Scope(const char *name)
+      : name(name)
+    {
+      Timer::start_section(name);
+    }
+
+    ~Scope()
+    {
+      Timer::end_section(name);
+    }
+
+    Scope(const Scope &) = delete;
+    Scope &
+    operator=(const Scope &) = delete;
+    Scope(Scope &&)          = delete;
+    Scope &
+    operator=(Scope &&) = delete;
+
+  private:
+    const char *name;
+  };
 
   /**
    * @brief Start a new timer section.

--- a/src/core/pde_problem.cc
+++ b/src/core/pde_problem.cc
@@ -65,7 +65,8 @@ PDEProblem<dim, degree, number>::PDEProblem(
   PhaseFieldTools<dim>                                          &_pf_tools,
   const std::shared_ptr<const PDEOperator<dim, degree, number>> &_pde_operator,
   const std::shared_ptr<const PDEOperator<dim, degree, float>>  &_pde_operator_float)
-  : user_inputs(&_user_inputs)
+  : timer_scope("Problem")
+  , user_inputs(&_user_inputs)
   , pf_tools(&_pf_tools)
   , mg_info(_user_inputs)
   , triangulation_handler(_user_inputs, mg_info)
@@ -488,8 +489,6 @@ PDEProblem<dim, degree, number>::run()
     << std::flush;
 
   solve();
-
-  Timer::print_summary();
 }
 
 #include "core/pde_problem.inst"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The PR follows our guidelines (formatting & style)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Timer is now hierarchical so we get something like this when not using Caliper
```
=====================================================================================================
  PRISMS-PF Timing Summary
=====================================================================================================
Section                                                N Calls  Wall Time (s)  CPU Time (s)  % Parent
-----------------------------------------------------------------------------------------------------
PDEProblem                                                   1         15.402        22.243  100.000%
  |- Initialization                                          1          0.470         0.580    3.049%
    |- Create FESystem                                       1          0.000         0.001    0.065%
    |- Generate mesh                                         1          0.101         0.090   21.560%
    |- reinitialize DoFHandlers                              1          0.015         0.017    3.225%
    |- Create constraints                                    1          0.007         0.007    1.445%
    |- reinitialize matrix-free objects                      1          0.030         0.044    6.439%
    |- reinitialize solution set                             1          0.000         0.002    0.066%
    |- reinitialize invm                                     1          0.001         0.002    0.188%
    |- reinitialize element volumes                          1          0.000         0.000    0.001%
    |- compute element volumes                               1          0.005         0.007    1.123%
    |- Solver initialization                                 1          0.202         0.209   43.078%
    |- Update ghosts                                         1          0.000         0.000    0.001%
    |- Auxiliary solver                                      1          0.000         0.000    0.000%
    |- Nonexplicit linear solver                             1          0.000         0.000    0.000%
    |- Nonexplicit self-nonlinear solver                     1          0.000         0.000    0.000%
    |- Nonexplicit co-nonlinear solver                       1          0.000         0.000    0.000%
    |- Postprocess solver                                    1          0.004         0.005    0.800%
      |- Zero ghosts                                         1          0.000         0.000    0.122%
      |- Update ghosts                                       1          0.000         0.000    0.082%
    |- Output                                                1          0.103         0.195   21.946%
  |- Solve Increment                                      5000         14.030        14.581   91.090%
    |- Update time-dependent constraints                  5000          0.010         0.105    0.070%
    |- Explicit solver                                    5000         13.873        13.366   98.880%
      |- Zero ghosts                                      5000          0.017         0.143    0.121%
      |- Update ghosts                                    5000          0.008         0.022    0.059%
    |- Nonexplicit auxiliary solver                       5000          0.007         0.029    0.047%
    |- Nonexplicit linear solver                          5000          0.006         0.045    0.046%
    |- Nonexplicit self-nonlinear solver                  5000          0.007         0.062    0.047%
    |- Nonexplicit co-nonlinear solver                    5000          0.007         0.069    0.047%
    |- Postprocess solver                                    5          0.016         0.022    0.116%
      |- Zero ghosts                                         5          0.000         0.000    0.081%
      |- Update ghosts                                       5          0.000         0.000    0.055%
  |- Output                                                  5          0.432         0.925    2.805%
=====================================================================================================
```
Caliper is still better because it provides more information, but this will let our users see what eats of the most time in their simulation.


* **What is the current behavior?** (You can also link to an open issue here)
Default deal.II output, which prints a flat unordered list at the end.


* **What is the new behavior (if this is a feature change)?**
Hierarchical!


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope


* **Other information**:
Closes #664, #823, #822, #351