### PR TITLE
Support xdmf output

### DIFF
--- a/include/prismspf/core/solution_output.h
+++ b/include/prismspf/core/solution_output.h
@@ -142,6 +142,41 @@ public:
         std::ofstream     vtk_output(filename);
         data_out.write_vtk(vtk_output);
       }
+    else if (file_type == "xdmf")
+      {
+#ifdef DEAL_II_WITH_HDF5
+        std::ostringstream increment_stream;
+        increment_stream << std::setw(static_cast<int>(n_trailing_digits))
+                         << std::setfill('0') << increment;
+
+        const std::string h5_filename =
+          file_prefix + "_" + increment_stream.str() + ".h5";
+        const std::string xdmf_filename = file_prefix + ".xdmf";
+
+        // Prepare the data filter
+        dealii::DataOutBase::DataOutFilter data_filter(
+          dealii::DataOutBase::DataOutFilterFlags(true, true));
+        data_out.write_filtered_data(data_filter);
+
+        // Write binary HDF5
+        data_out.write_hdf5_parallel(data_filter, h5_filename, MPI_COMM_WORLD);
+
+        // Create the XDMF wrapper for this timestep
+        std::vector<dealii::XDMFEntry> xdmf_entries;
+        xdmf_entries.push_back(data_out.create_xdmf_entry(data_filter,
+                                                          h5_filename,
+                                                          increment,
+                                                          MPI_COMM_WORLD));
+
+        data_out.write_xdmf_file(xdmf_entries, xdmf_filename, MPI_COMM_WORLD);
+#else
+        AssertThrow(
+          false,
+          dealii::ExcMessage(
+            "You are trying to write an XDMF file as an output; however, PRISMS-PF "
+            "was not built with HDF5. Please reconfig PRISMS-PF with HDF5."));
+#endif
+      }
     else
       {
         AssertThrow(false, UnreachableCode());

--- a/include/prismspf/core/solution_output.h
+++ b/include/prismspf/core/solution_output.h
@@ -151,7 +151,8 @@ public:
 
         const std::string h5_filename =
           file_prefix + "_" + increment_stream.str() + ".h5";
-        const std::string xdmf_filename = file_prefix + ".xdmf";
+        const std::string xdmf_filename =
+          file_prefix + "_" + increment_stream.str() + ".xdmf";
 
         // Prepare the data filter
         dealii::DataOutBase::DataOutFilter data_filter(

--- a/include/prismspf/core/solution_output.h
+++ b/include/prismspf/core/solution_output.h
@@ -173,8 +173,8 @@ public:
         AssertThrow(
           false,
           dealii::ExcMessage(
-            "You are trying to write an XDMF file as an output; however, PRISMS-PF "
-            "was not built with HDF5. Please reconfig PRISMS-PF with HDF5."));
+            "You are trying to write an XDMF file as an output; however, deal.II "
+            "was not built with HDF5. Please reconfig deal.II with HDF5."));
 #endif
       }
     else

--- a/include/prismspf/user_inputs/io_parameters.h
+++ b/include/prismspf/user_inputs/io_parameters.h
@@ -132,10 +132,11 @@ public:
                                     dealii::Patterns::Anything(),
                                     "The base name for the output file, before the time "
                                     "step and processor info are added.");
-    parameter_handler.declare_entry("file type",
-                                    "vtu",
-                                    dealii::Patterns::Selection("vtu|vtk|pvtu"),
-                                    "The output file type (either vtu, pvtu, or vtk).");
+    parameter_handler.declare_entry(
+      "file type",
+      "vtu",
+      dealii::Patterns::Selection("vtu|vtk|pvtu|xdmf"),
+      "The output file type (either vtu, pvtu, vtk, or xdmf).");
     parameter_handler.declare_entry(
       "subdivisions",
       "0",

--- a/src/user_inputs/input_file_reader.cc
+++ b/src/user_inputs/input_file_reader.cc
@@ -488,10 +488,11 @@ InputFileReader::declare_output_parameters()
                                     dealii::Patterns::Anything(),
                                     "The name for the output file, before the "
                                     "time step and processor info are added.");
-    parameter_handler.declare_entry("file type",
-                                    "vtu",
-                                    dealii::Patterns::Selection("vtu|vtk|pvtu"),
-                                    "The output file type (either vtu, pvtu, or vtk).");
+    parameter_handler.declare_entry(
+      "file type",
+      "vtu",
+      dealii::Patterns::Selection("vtu|vtk|pvtu|xdmf"),
+      "The output file type (either vtu, pvtu, vtk, or xdmf).");
     parameter_handler.declare_entry(
       "subdivisions",
       "0",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The PR follows our guidelines (formatting & style)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Write XDMF output (requires deal.II to be built with HDF5)

```
subsection output
  file type xdmf
  ...
end
```

* **What is the current behavior?** (You can also link to an open issue here)
Support vtu, vtk, and pvtu.

* **What is the new behavior (if this is a feature change)?**
Support xdmf


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
For now, I generate one XDMF+H5 file per output time step.

*TODO*: Create a master XDMF file that includes all time steps.

To do this, we may need to keep a global `SolutionOutput` in `Problem`, so we save the information of all previous time steps.