### PR TITLE
Remove excess operators

### DIFF
--- a/include/prismspf/solvers/explicit_solver.h
+++ b/include/prismspf/solvers/explicit_solver.h
@@ -41,54 +41,50 @@ public:
     SolverBase<dim, degree, number>::init(all_dependeny_sets);
     unsigned int num_levels = solve_context->get_dof_manager().get_dof_handlers().size();
     // Initialize rhs_operators
-    rhs_operators.reserve(num_levels);
-    for (unsigned int relative_level = 0; relative_level < num_levels; ++relative_level)
-      {
-        rhs_operators.emplace_back(solve_context->get_pde_operator(),
-                                   &PDEOperatorBase<dim, degree, number>::compute_rhs,
-                                   solve_context->get_field_attributes(),
-                                   solve_context->get_solution_indexer(),
-                                   relative_level,
-                                   solve_block.dependencies_rhs,
-                                   solve_context->get_simulation_timer());
-        rhs_operators[relative_level].initialize(solutions);
-        rhs_operators[relative_level].set_scaling_diagonal(
-          true,
-          solve_context->get_invm_manager().get_invm(
-            solve_context->get_field_attributes(),
-            solve_block.field_indices,
-            relative_level));
-      }
+
+    rhs_operator =
+      MFOperator<dim, degree, number>(solve_context->get_pde_operator(),
+                                      &PDEOperatorBase<dim, degree, number>::compute_rhs,
+                                      solve_context->get_field_attributes(),
+                                      solve_context->get_solution_indexer(),
+                                      0,
+                                      solve_block.dependencies_rhs,
+                                      solve_context->get_simulation_timer());
+    rhs_operator.initialize(solutions);
+    rhs_operator.set_scaling_diagonal(
+      true,
+      solve_context->get_invm_manager().get_invm(solve_context->get_field_attributes(),
+                                                 solve_block.field_indices,
+                                                 0));
   }
 
   /**
    * @brief Solve for a single update step.
    */
   void
-  solve_level(unsigned int relative_level) override
+  solve_impl() override
   {
     // Zero out the ghosts
     Timer::start_section("Zero ghosts");
-    solutions.zero_out_ghosts(relative_level);
+    solutions.zero_out_ghosts(0);
     Timer::end_section("Zero ghosts");
 
-    rhs_operators[relative_level].compute_operator(
-      solutions.get_solution_full_vector(relative_level));
+    rhs_operator.compute_operator(solutions.get_solution_full_vector(0));
 
     // Apply constraints
-    solutions.apply_constraints(relative_level);
+    solutions.apply_constraints(0);
 
     // Update the ghosts
     Timer::start_section("Update ghosts");
-    solutions.update_ghosts(relative_level);
+    solutions.update_ghosts(0);
     Timer::end_section("Update ghosts");
   }
 
 private:
   /**
-   * @brief Matrix free operators for each level
+   * @brief Matrix free operator.
    */
-  std::vector<MFOperator<dim, degree, number>> rhs_operators;
+  MFOperator<dim, degree, number> rhs_operator;
 };
 
 PRISMS_PF_END_NAMESPACE

--- a/include/prismspf/solvers/explicit_solver.h
+++ b/include/prismspf/solvers/explicit_solver.h
@@ -29,10 +29,18 @@ class ExplicitSolver : public SolverBase<dim, degree, number>
 public:
   /**
    * @brief Constructor.
+   * @pre Solve context has initialized members.
    */
   ExplicitSolver(SolveBlock                               _solve_block,
                  const SolveContext<dim, degree, number> &_solve_context)
     : SolverBase<dim, degree, number>(_solve_block, _solve_context)
+    , rhs_operator(solve_context->get_pde_operator(),
+                   &PDEOperatorBase<dim, degree, number>::compute_rhs,
+                   solve_context->get_field_attributes(),
+                   solve_context->get_solution_indexer(),
+                   0,
+                   solve_block.dependencies_rhs,
+                   solve_context->get_simulation_timer())
   {}
 
   void
@@ -41,15 +49,6 @@ public:
     SolverBase<dim, degree, number>::init(all_dependeny_sets);
     unsigned int num_levels = solve_context->get_dof_manager().get_dof_handlers().size();
     // Initialize rhs_operators
-
-    rhs_operator =
-      MFOperator<dim, degree, number>(solve_context->get_pde_operator(),
-                                      &PDEOperatorBase<dim, degree, number>::compute_rhs,
-                                      solve_context->get_field_attributes(),
-                                      solve_context->get_solution_indexer(),
-                                      0,
-                                      solve_block.dependencies_rhs,
-                                      solve_context->get_simulation_timer());
     rhs_operator.initialize(solutions);
     rhs_operator.set_scaling_diagonal(
       true,

--- a/include/prismspf/solvers/linear_solver.h
+++ b/include/prismspf/solvers/linear_solver.h
@@ -61,51 +61,39 @@ public:
   init(const std::list<DependencyMap> &all_dependeny_sets) override
   {
     SolverBase<dim, degree, number>::init(all_dependeny_sets);
-    unsigned int num_levels = solve_context->get_dof_manager().get_dof_handlers().size();
-    rhs_vector.resize(num_levels);
-    for (unsigned int relative_level = 0; relative_level < num_levels; ++relative_level)
-      {
-        rhs_vector[relative_level].reinit(
-          solutions.get_solution_full_vector(relative_level));
-      }
-    // Initialize rhs_operators
-    rhs_operators.reserve(num_levels);
-    for (unsigned int relative_level = 0; relative_level < num_levels; ++relative_level)
-      {
-        rhs_operators.emplace_back(solve_context->get_pde_operator(),
-                                   &PDEOperatorBase<dim, degree, number>::compute_rhs,
-                                   solve_context->get_field_attributes(),
-                                   solve_context->get_solution_indexer(),
-                                   relative_level,
-                                   solve_block.dependencies_rhs,
-                                   solve_context->get_simulation_timer());
-        rhs_operators[relative_level].initialize(solutions);
-        rhs_operators[relative_level].set_scaling_diagonal(
-          lin_params.tolerance_type != AbsoluteResidual,
-          solve_context->get_invm_manager().get_invm_sqrt(
-            solve_context->get_field_attributes(),
-            solve_block.field_indices,
-            relative_level));
-      }
-    // Initialize lhs_operators
-    lhs_operators.reserve(num_levels);
-    for (unsigned int relative_level = 0; relative_level < num_levels; ++relative_level)
-      {
-        lhs_operators.emplace_back(solve_context->get_pde_operator(),
-                                   &PDEOperatorBase<dim, degree, number>::compute_lhs,
-                                   solve_context->get_field_attributes(),
-                                   solve_context->get_solution_indexer(),
-                                   relative_level,
-                                   solve_block.dependencies_lhs,
-                                   solve_context->get_simulation_timer());
-        lhs_operators[relative_level].initialize(solutions);
-        lhs_operators[relative_level].set_scaling_diagonal(
-          lin_params.tolerance_type != AbsoluteResidual,
-          solve_context->get_invm_manager().get_invm_sqrt(
-            solve_context->get_field_attributes(),
-            solve_block.field_indices,
-            relative_level));
-      }
+    rhs_vector.reinit(solutions.get_solution_full_vector(0));
+
+    // Initialize rhs_operator
+    rhs_operator =
+      MFOperator<dim, degree, number>(solve_context->get_pde_operator(),
+                                      &PDEOperatorBase<dim, degree, number>::compute_rhs,
+                                      solve_context->get_field_attributes(),
+                                      solve_context->get_solution_indexer(),
+                                      0,
+                                      solve_block.dependencies_rhs,
+                                      solve_context->get_simulation_timer());
+    rhs_operator.initialize(solutions);
+    rhs_operator.set_scaling_diagonal(lin_params.tolerance_type != AbsoluteResidual,
+                                      solve_context->get_invm_manager().get_invm_sqrt(
+                                        solve_context->get_field_attributes(),
+                                        solve_block.field_indices,
+                                        0));
+    // Initialize lhs_operator
+    lhs_operator =
+      MFOperator<dim, degree, number>(solve_context->get_pde_operator(),
+                                      &PDEOperatorBase<dim, degree, number>::compute_lhs,
+                                      solve_context->get_field_attributes(),
+                                      solve_context->get_solution_indexer(),
+                                      0,
+                                      solve_block.dependencies_lhs,
+                                      solve_context->get_simulation_timer());
+    lhs_operator.initialize(solutions);
+    lhs_operator.set_scaling_diagonal(lin_params.tolerance_type != AbsoluteResidual,
+                                      solve_context->get_invm_manager().get_invm_sqrt(
+                                        solve_context->get_field_attributes(),
+                                        solve_block.field_indices,
+                                        0));
+
     linear_solver_control.set_max_steps(lin_params.max_iterations);
     linear_solver_control.set_tolerance(lin_params.tolerance * normalization_value());
     lin_solver.select(lin_params.solver_type);
@@ -123,12 +111,8 @@ public:
   reinit() override
   {
     SolverBase<dim, degree, number>::reinit();
-    const unsigned int num_levels = rhs_vector.size();
-    for (unsigned int relative_level = 0; relative_level < num_levels; ++relative_level)
-      {
-        rhs_vector[relative_level].reinit(
-          solutions.get_solution_full_vector(relative_level));
-      }
+    rhs_vector.reinit(solutions.get_solution_full_vector(0));
+
     inhomogeneous_values.reinit(solutions.get_solution_full_vector(0));
     solutions.apply_constraints(inhomogeneous_values, 0);
     inhomogeneous_rhs.reinit(solutions.get_solution_full_vector(0));
@@ -138,55 +122,50 @@ public:
    * @brief Solve for a single update step.
    */
   void
-  solve_level(unsigned int relative_level) override
+  solve_impl() override
   {
     // Zero out the ghosts
     Timer::start_section("Zero ghosts");
-    solutions.zero_out_ghosts(relative_level);
+    solutions.zero_out_ghosts(0);
     Timer::end_section("Zero ghosts");
 
     // Set up rhs vector
-    rhs_operators[relative_level].compute_operator(rhs_vector[relative_level]);
-    if (relative_level == 0)
-      {
-        // Note 1. Use the previous result of the linear solve without nonzero dirichlet
-        // as the initial guess in the next increment. See Note 2. `inhomogeneous_rhs` is
-        // not actually what it is being used as here, we just don't want to allocate a
-        // whole new vector for this purpose
-        solutions.get_solution_full_vector(0).swap(inhomogeneous_rhs);
-        // Get the homogeneous rhs
-        lhs_operators[0].read_plain = true;
-        lhs_operators[0].compute_operator(inhomogeneous_rhs, inhomogeneous_values);
-        lhs_operators[0].read_plain = false;
-        rhs_vector[0] -= inhomogeneous_rhs;
-      }
-    // Linear solve
-    do_linear_solve(rhs_vector[relative_level],
-                    lhs_operators[relative_level],
-                    solutions.get_solution_full_vector(relative_level));
+    rhs_operator.compute_operator(rhs_vector);
 
-    if (relative_level == 0)
-      {
-        // Note 2. Make a copy of the solution to use as the initial guess in the next
-        // increment. See Note 1. `inhomogeneous_rhs` is not actually what it is being
-        // used as here, we just don't want to allocate a whole new vector for this
-        // purpose
-        inhomogeneous_rhs = solutions.get_solution_full_vector(0);
-        // Add back in nonzero dirichlet conditions
-        solutions.get_solution_full_vector(0) += inhomogeneous_values;
-      }
+    // Note 1. Use the previous result of the linear solve without nonzero dirichlet
+    // as the initial guess in the next increment. See Note 2. `inhomogeneous_rhs` is
+    // not actually what it is being used as here, we just don't want to allocate a
+    // whole new vector for this purpose
+    solutions.get_solution_full_vector(0).swap(inhomogeneous_rhs);
+    // Get the homogeneous rhs
+    lhs_operator.read_plain = true;
+    lhs_operator.compute_operator(inhomogeneous_rhs, inhomogeneous_values);
+    lhs_operator.read_plain = false;
+    rhs_vector -= inhomogeneous_rhs;
+
+    // Linear solve
+    do_linear_solve(rhs_vector, lhs_operator, solutions.get_solution_full_vector(0));
+
+    // Note 2. Make a copy of the solution to use as the initial guess in the next
+    // increment. See Note 1. `inhomogeneous_rhs` is not actually what it is being
+    // used as here, we just don't want to allocate a whole new vector for this
+    // purpose
+    inhomogeneous_rhs = solutions.get_solution_full_vector(0);
+    // Add back in nonzero dirichlet conditions
+    solutions.get_solution_full_vector(0) += inhomogeneous_values;
+
     // Apply constraints
-    solutions.apply_constraints(relative_level);
+    solutions.apply_constraints(0);
 
     // Update the ghosts
     Timer::start_section("Update ghosts");
-    solutions.update_ghosts(relative_level);
+    solutions.update_ghosts(0);
     Timer::end_section("Update ghosts");
   }
 
   int
   do_linear_solve(BlockVector<number>             &b_vector,
-                  MFOperator<dim, degree, number> &lhs_operator,
+                  MFOperator<dim, degree, number> &lhs_matrix,
                   BlockVector<number>             &x_vector)
   {
     // Linear solve
@@ -194,17 +173,17 @@ public:
       {
         if (lin_params.preconditioner == None)
           {
-            lin_solver.solve(lhs_operator,
+            lin_solver.solve(lhs_matrix,
                              x_vector,
                              b_vector,
                              dealii::PreconditionIdentity());
           }
         if (lin_params.preconditioner == Chebyshev)
           {
-            lhs_operator.reinit_matrix_diagonal(x_vector);
-            lhs_operator.eval_matrix_diagonal();
+            lhs_matrix.reinit_matrix_diagonal(x_vector);
+            lhs_matrix.eval_matrix_diagonal();
 
-            lin_solver.solve(lhs_operator, x_vector, b_vector, precond_chebyshev);
+            lin_solver.solve(lhs_matrix, x_vector, b_vector, precond_chebyshev);
           }
       }
     catch (...) // TODO: more specific catch so that we dont ignore
@@ -230,12 +209,12 @@ public:
 
 protected:
   /**
-   * @brief Matrix free operators for each level
+   * @brief Matrix free operators
    */
-  std::vector<MFOperator<dim, degree, number>> rhs_operators;
+  MFOperator<dim, degree, number> rhs_operator;
 
-  std::vector<MFOperator<dim, degree, number>> lhs_operators;
-  std::vector<BlockVector<number>>             rhs_vector;
+  MFOperator<dim, degree, number> lhs_operator;
+  BlockVector<number>             rhs_vector;
 
   double
   normalization_value()
@@ -273,10 +252,10 @@ protected:
     precond_data.smoothing_range = lin_params.smoothing_range; // ≈ λ_min / λ_max
     precond_data.eig_cg_n_iterations =
       lin_params.eig_cg_n_iterations; // estimate λ_max via CG
-    lhs_operators[0].reinit_matrix_diagonal(solutions.get_solution_full_vector(0));
-    precond_data.preconditioner = lhs_operators[0].get_matrix_diagonal_inverse();
+    lhs_operator.reinit_matrix_diagonal(solutions.get_solution_full_vector(0));
+    precond_data.preconditioner = lhs_operator.get_matrix_diagonal_inverse();
 
-    precond_chebyshev.initialize(lhs_operators[0], precond_data);
+    precond_chebyshev.initialize(lhs_operator, precond_data);
   }
 
 private:

--- a/include/prismspf/solvers/linear_solver.h
+++ b/include/prismspf/solvers/linear_solver.h
@@ -45,6 +45,7 @@ protected:
 public:
   /**
    * @brief Constructor.
+   * @pre Solve context has initialized members.
    */
   LinearSolver(SolveBlock                               _solve_block,
                const SolveContext<dim, degree, number> &_solve_context)
@@ -52,6 +53,20 @@ public:
     , lin_params(
         solve_context->get_user_inputs().linear_solve_parameters.linear_solvers.at(
           solve_block.id))
+    , rhs_operator(solve_context->get_pde_operator(),
+                   &PDEOperatorBase<dim, degree, number>::compute_rhs,
+                   solve_context->get_field_attributes(),
+                   solve_context->get_solution_indexer(),
+                   0,
+                   solve_block.dependencies_rhs,
+                   solve_context->get_simulation_timer())
+    , lhs_operator(solve_context->get_pde_operator(),
+                   &PDEOperatorBase<dim, degree, number>::compute_lhs,
+                   solve_context->get_field_attributes(),
+                   solve_context->get_solution_indexer(),
+                   0,
+                   solve_block.dependencies_lhs,
+                   solve_context->get_simulation_timer())
   {}
 
   /**
@@ -64,14 +79,6 @@ public:
     rhs_vector.reinit(solutions.get_solution_full_vector(0));
 
     // Initialize rhs_operator
-    rhs_operator =
-      MFOperator<dim, degree, number>(solve_context->get_pde_operator(),
-                                      &PDEOperatorBase<dim, degree, number>::compute_rhs,
-                                      solve_context->get_field_attributes(),
-                                      solve_context->get_solution_indexer(),
-                                      0,
-                                      solve_block.dependencies_rhs,
-                                      solve_context->get_simulation_timer());
     rhs_operator.initialize(solutions);
     rhs_operator.set_scaling_diagonal(lin_params.tolerance_type != AbsoluteResidual,
                                       solve_context->get_invm_manager().get_invm_sqrt(
@@ -79,14 +86,6 @@ public:
                                         solve_block.field_indices,
                                         0));
     // Initialize lhs_operator
-    lhs_operator =
-      MFOperator<dim, degree, number>(solve_context->get_pde_operator(),
-                                      &PDEOperatorBase<dim, degree, number>::compute_lhs,
-                                      solve_context->get_field_attributes(),
-                                      solve_context->get_solution_indexer(),
-                                      0,
-                                      solve_block.dependencies_lhs,
-                                      solve_context->get_simulation_timer());
     lhs_operator.initialize(solutions);
     lhs_operator.set_scaling_diagonal(lin_params.tolerance_type != AbsoluteResidual,
                                       solve_context->get_invm_manager().get_invm_sqrt(

--- a/include/prismspf/solvers/mg_solver.h
+++ b/include/prismspf/solvers/mg_solver.h
@@ -57,7 +57,7 @@ public:
    * @brief Solve for a single update step.
    */
   void
-  solve_level(unsigned int relative_level) override
+  solve_impl() override
   {}
 
   void

--- a/include/prismspf/solvers/newton_solver.h
+++ b/include/prismspf/solvers/newton_solver.h
@@ -32,8 +32,8 @@ protected:
   using SolverBase<dim, degree, number>::solve_block;
   using LinearSolver<dim, degree, number>::do_linear_solve;
   using LinearSolver<dim, degree, number>::normalization_value;
-  using LinearSolver<dim, degree, number>::lhs_operators;
-  using LinearSolver<dim, degree, number>::rhs_operators;
+  using LinearSolver<dim, degree, number>::lhs_operator;
+  using LinearSolver<dim, degree, number>::rhs_operator;
   using LinearSolver<dim, degree, number>::rhs_vector;
 
 public:
@@ -55,13 +55,7 @@ public:
   init(const std::list<DependencyMap> &all_dependeny_sets) override
   {
     LinearSolver<dim, degree, number>::init(all_dependeny_sets);
-    unsigned int num_levels = solve_context->get_dof_manager().get_dof_handlers().size();
-    newton_updates.resize(num_levels);
-    for (unsigned int relative_level = 0; relative_level < num_levels; ++relative_level)
-      {
-        newton_updates[relative_level].reinit(
-          solutions.get_solution_full_vector(relative_level));
-      }
+    newton_update.reinit(solutions.get_solution_full_vector(0));
   }
 
   /**
@@ -71,34 +65,28 @@ public:
   reinit() override
   {
     LinearSolver<dim, degree, number>::reinit();
-    const unsigned int num_levels = newton_updates.size();
-    for (unsigned int relative_level = 0; relative_level < num_levels; ++relative_level)
-      {
-        newton_updates[relative_level].reinit(
-          solutions.get_solution_full_vector(relative_level));
-      }
+    newton_update.reinit(solutions.get_solution_full_vector(0));
   }
 
   /**
    * @brief Solve for a single update step.
    */
   void
-  solve_level(unsigned int relative_level) override
+  solve_impl() override
   {
     const number newton_step_length = newton_params.step_length;
     const number newton_tolerance = newton_params.tolerance_value * normalization_value();
     unsigned int newton_max_iterations = newton_params.max_iterations;
 
-    BlockVector<number>             &newton_residual = rhs_vector[relative_level];
-    BlockVector<number>             &newton_update   = newton_updates[relative_level];
-    MFOperator<dim, degree, number> &rhs_op          = rhs_operators[relative_level];
-    MFOperator<dim, degree, number> &lhs_op          = lhs_operators[relative_level];
+    BlockVector<number>             &newton_residual = rhs_vector;
+    MFOperator<dim, degree, number> &rhs_op          = rhs_operator;
+    MFOperator<dim, degree, number> &lhs_op          = lhs_operator;
     // TODO: setup initial guess for solution vector. Maybe use old_solution if
     // available.
-    if (!solutions.get_solution_level(relative_level).old_solutions.empty())
+    if (!solutions.get_solution_level(0).old_solutions.empty())
       {
-        solutions.get_solution_full_vector(relative_level) =
-          solutions.get_old_solution_full_vector(0, relative_level);
+        solutions.get_solution_full_vector(0) =
+          solutions.get_old_solution_full_vector(0, 0);
       }
 
     // Newton iteration loop.
@@ -109,8 +97,8 @@ public:
     while (newton_unconverged && iter < newton_max_iterations)
       {
         // Apply constraints to solution vector
-        solutions.apply_constraints(relative_level);
-        solutions.update_ghosts(relative_level);
+        solutions.apply_constraints(0);
+        solutions.update_ghosts(0);
 
         // Solve for Newton-residual (r)
         Timer::start_section("Zero ghosts");
@@ -132,15 +120,14 @@ public:
         newton_update.update_ghost_values();
 
         // Zero out the ghosts
-        solutions.get_solution_full_vector(relative_level).zero_out_ghost_values();
+        solutions.get_solution_full_vector(0).zero_out_ghost_values();
 
         // Perform Newton update.
-        solutions.get_solution_full_vector(relative_level)
-          .add(newton_step_length, newton_update);
+        solutions.get_solution_full_vector(0).add(newton_step_length, newton_update);
 
         // Update the ghosts
         Timer::start_section("Update ghosts");
-        solutions.update_ghosts(relative_level);
+        solutions.update_ghosts(0);
         Timer::end_section("Update ghosts");
 
         iter++;
@@ -167,8 +154,8 @@ public:
   }
 
 protected:
-  std::vector<BlockVector<number>> newton_updates; //"change" term
-  NonlinearSolverParameters        newton_params;
+  BlockVector<number>       newton_update; //"change" term
+  NonlinearSolverParameters newton_params;
 };
 
 PRISMS_PF_END_NAMESPACE

--- a/include/prismspf/solvers/newton_solver.h
+++ b/include/prismspf/solvers/newton_solver.h
@@ -39,6 +39,7 @@ protected:
 public:
   /**
    * @brief Constructor.
+   * @pre Solve context has initialized members.
    */
   NewtonSolver(SolveBlock                               _solve_block,
                const SolveContext<dim, degree, number> &_solve_context)

--- a/include/prismspf/solvers/solver_base.h
+++ b/include/prismspf/solvers/solver_base.h
@@ -31,6 +31,7 @@ class SolverBase
 public:
   /**
    * @brief Constructor.
+   * @pre Solve context has initialized members.
    */
   SolverBase(SolveBlock                               _solve_block,
              const SolveContext<dim, degree, number> &_solve_context)

--- a/include/prismspf/solvers/solver_base.h
+++ b/include/prismspf/solvers/solver_base.h
@@ -23,8 +23,6 @@
 
 #include <prismspf/config.h>
 
-#include <memory>
-
 PRISMS_PF_BEGIN_NAMESPACE
 
 template <unsigned int dim, unsigned int degree, typename number>
@@ -104,10 +102,10 @@ public:
   }
 
   /**
-   * @brief Solve one level.
+   * @brief Solve implementation.
    */
   virtual void
-  solve_level([[maybe_unused]] unsigned int relative_level = 0)
+  solve_impl()
   {}
 
   /**
@@ -123,7 +121,7 @@ public:
         set_initial_condition();
         return;
       }
-    this->solve_level(0);
+    this->solve_impl();
     if (solve_context->get_simulation_timer().get_increment() == 0)
       {
         solutions.apply_initial_condition_for_old_fields();


### PR DESCRIPTION
I was once considering having support for applying solvers to individual mg levels. Definitely not doing this anymore, so that part of the infrastructure can be removed.