### PR TITLE
Temporary? Matrixfree fix

### DIFF
--- a/include/prismspf/core/invm_manager.h
+++ b/include/prismspf/core/invm_manager.h
@@ -64,13 +64,12 @@ public:
       constraint_manager.get_generic_constraints();
     for (unsigned int i = 0; i < data.size(); ++i)
       {
-        for (unsigned int rank = 0; rank < 2; ++rank)
-          {
-            data[i][rank].reinit(SystemWide<dim, degree>::mapping,
-                                 dof_handlers[i][rank],
-                                 constraints[i][rank],
-                                 SystemWide<dim, degree>::quadrature);
-          }
+        data[i].reinit(SystemWide<dim, degree>::mapping,
+                       std::vector<const dealii::DoFHandler<dim> *>(
+                         {&dof_handlers[i][0], &dof_handlers[i][1]}),
+                       std::vector<const dealii::AffineConstraints<number> *>(
+                         {&constraints[i][0], &constraints[i][1]}),
+                       SystemWide<dim, degree>::quadrature);
       }
   }
 
@@ -214,15 +213,15 @@ private:
       {
         if (calculate_scalar)
           {
-            jxw_scalar[i].reinit(data[i][0].get_vector_partitioner());
-            invm_scalar[i].reinit(data[i][0].get_vector_partitioner());
-            invm_sqrt_scalar[i].reinit(data[i][0].get_vector_partitioner());
+            jxw_scalar[i].reinit(data[i].get_vector_partitioner(0));
+            invm_scalar[i].reinit(data[i].get_vector_partitioner(0));
+            invm_sqrt_scalar[i].reinit(data[i].get_vector_partitioner(0));
           }
         if (calculate_vector)
           {
-            jxw_vector[i].reinit(data[i][1].get_vector_partitioner());
-            invm_vector[i].reinit(data[i][1].get_vector_partitioner());
-            invm_sqrt_vector[i].reinit(data[i][1].get_vector_partitioner());
+            jxw_vector[i].reinit(data[i].get_vector_partitioner(1));
+            invm_vector[i].reinit(data[i].get_vector_partitioner(1));
+            invm_sqrt_vector[i].reinit(data[i].get_vector_partitioner(1));
           }
       }
   }
@@ -235,7 +234,7 @@ private:
   {
     for (unsigned int i = 0; i < data.size(); ++i)
       {
-        data[i][0].cell_loop(&InvMManager::compute_local_scalar, this, jxw_scalar[i], 0);
+        data[i].cell_loop(&InvMManager::compute_local_scalar, this, jxw_scalar[i], 0);
         invert(invm_scalar[i], jxw_scalar[i]);
         //
         sqrt(invm_sqrt_scalar[i], invm_scalar[i]);
@@ -250,7 +249,7 @@ private:
   {
     for (unsigned int i = 0; i < data.size(); ++i)
       {
-        data[i][1].cell_loop(&InvMManager::compute_local_vector, this, jxw_vector[i], 0);
+        data[i].cell_loop(&InvMManager::compute_local_vector, this, jxw_vector[i], 0);
         invert(invm_vector[i], jxw_vector[i]);
         //
         sqrt(invm_sqrt_vector[i], invm_vector[i]);
@@ -266,7 +265,7 @@ private:
                        [[maybe_unused]] const int                  &src,
                        const std::pair<unsigned int, unsigned int> &cell_range) const
   {
-    dealii::FEEvaluation<dim, degree, degree + 1, 1, number, ScalarValue> fe_eval(_data);
+    dealii::FEEvaluation<dim, degree, degree + 1, 1, number> fe_eval(_data, 0);
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
         fe_eval.reinit(cell);
@@ -285,7 +284,7 @@ private:
                        [[maybe_unused]] const int                  &src,
                        const std::pair<unsigned int, unsigned int> &cell_range) const
   {
-    dealii::FEEvaluation<dim, degree, degree + 1, dim, number> fe_eval(_data);
+    dealii::FEEvaluation<dim, degree, degree + 1, dim, number> fe_eval(_data, 1);
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
         fe_eval.reinit(cell);
@@ -327,7 +326,7 @@ private:
   /**
    * @brief Matrix-free object.
    */
-  std::vector<std::array<MatrixFree<dim, number>, 2>> data;
+  std::vector<MatrixFree<dim, number>> data;
 
   unsigned int num_levels;
 

--- a/include/prismspf/core/invm_manager.h
+++ b/include/prismspf/core/invm_manager.h
@@ -62,6 +62,14 @@ public:
       dof_manager.get_dof_handlers();
     const std::vector<std::array<dealii::AffineConstraints<number>, 2>> &constraints =
       constraint_manager.get_generic_constraints();
+    using AdditionalData = typename MatrixFree<dim, number>::AdditionalData;
+    // TODO: maybe make the flags determined by user dependencies. (Though I doubt this
+    // is a significant source of runtime)
+    static const AdditionalData additional_data(
+      AdditionalData::TasksParallelScheme::partition_partition,
+      0,
+      dealii::update_values | dealii::update_JxW_values |
+        dealii::update_quadrature_points);
     for (unsigned int i = 0; i < data.size(); ++i)
       {
         data[i].reinit(SystemWide<dim, degree>::mapping,
@@ -69,8 +77,18 @@ public:
                          {&dof_handlers[i][0], &dof_handlers[i][1]}),
                        std::vector<const dealii::AffineConstraints<number> *>(
                          {&constraints[i][0], &constraints[i][1]}),
-                       SystemWide<dim, degree>::quadrature);
+                       SystemWide<dim, degree>::quadrature,
+                       additional_data);
       }
+  }
+
+  /**
+   * @brief Get the matrix free objects.
+   */
+  const std::vector<MatrixFree<dim, number>> &
+  get_matrix_free_vector() const
+  {
+    return data;
   }
 
   /**

--- a/include/prismspf/solvers/explicit_solver.h
+++ b/include/prismspf/solvers/explicit_solver.h
@@ -47,9 +47,10 @@ public:
   init(const std::list<DependencyMap> &all_dependeny_sets) override
   {
     SolverBase<dim, degree, number>::init(all_dependeny_sets);
-    unsigned int num_levels = solve_context->get_dof_manager().get_dof_handlers().size();
     // Initialize rhs_operators
-    rhs_operator.initialize(solutions);
+    rhs_operator.initialize(
+      solutions,
+      solve_context->get_invm_manager().get_matrix_free_vector()[0]);
     rhs_operator.set_scaling_diagonal(
       true,
       solve_context->get_invm_manager().get_invm(solve_context->get_field_attributes(),

--- a/include/prismspf/solvers/linear_solver.h
+++ b/include/prismspf/solvers/linear_solver.h
@@ -79,14 +79,18 @@ public:
     rhs_vector.reinit(solutions.get_solution_full_vector(0));
 
     // Initialize rhs_operator
-    rhs_operator.initialize(solutions);
+    rhs_operator.initialize(
+      solutions,
+      solve_context->get_invm_manager().get_matrix_free_vector()[0]);
     rhs_operator.set_scaling_diagonal(lin_params.tolerance_type != AbsoluteResidual,
                                       solve_context->get_invm_manager().get_invm_sqrt(
                                         solve_context->get_field_attributes(),
                                         solve_block.field_indices,
                                         0));
     // Initialize lhs_operator
-    lhs_operator.initialize(solutions);
+    lhs_operator.initialize(
+      solutions,
+      solve_context->get_invm_manager().get_matrix_free_vector()[0]);
     lhs_operator.set_scaling_diagonal(lin_params.tolerance_type != AbsoluteResidual,
                                       solve_context->get_invm_manager().get_invm_sqrt(
                                         solve_context->get_field_attributes(),

--- a/include/prismspf/solvers/mf_operator.h
+++ b/include/prismspf/solvers/mf_operator.h
@@ -141,10 +141,11 @@ public:
    * of handling this, but this is the least complicated for now.)
    */
   void
-  initialize(const GroupSolutionHandler<dim, number> &dst_solution)
+  initialize(const GroupSolutionHandler<dim, number> &dst_solution,
+             const MatrixFree<dim, number>           &matrix_free)
   {
     solve_block          = dst_solution.get_solve_block();
-    data                 = &(dst_solution.get_matrix_free(relative_level));
+    data                 = &matrix_free;
     field_to_block_index = dst_solution.get_global_to_block_index();
     for (unsigned int field_index : solve_block.field_indices)
       {


### PR DESCRIPTION
Use the generic matrix free from invm that begins with a scalar to perform all cell loop calls.
Note: I'm assuming the problem with the access pattern is only a matter of padding. If the actual access pattern is different, this might not be a true fix.