### PR TITLE
make DebugRelease not silly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_policy(VERSION 3.25)
 
 # Prohibit in-source build
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
-  message(FATAL_ERROR "In-source build prohibited.")
+  message(FATAL_ERROR "In-source build prohibited. Use a separate build directory.")
 endif()
 
 # Project declaration, language, and version
@@ -320,6 +320,11 @@ endif()
 
 # TODO: Add VTK
 
+# Set the build type to DebugRelease if unspecified
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "DebugRelease" CACHE STRING "Build type" FORCE)
+endif()
+
 # FetchCotent MakeAvailable for the other vendored dependencies
 set(PRISMS_PF_VENDORED_PACKAGES libassert)
 if(PRISMS_PF_UNIT_TESTS OR PRISMS_PF_REGRESSION_TESTS OR PRISMS_PF_PERFORMANCE_TESTS)
@@ -409,31 +414,24 @@ configure_file(cmake/templates.in cmake/templates @ONLY)
 
 if(CMAKE_BUILD_TYPE STREQUAL "DebugRelease")
   add_library(prisms_pf_debug)
-  add_library(prisms_pf_release)
+  add_library(prisms_pf)
 
   prisms_pf_configure_target(prisms_pf_debug "Debug")
-  prisms_pf_configure_target(prisms_pf_release "Release")
+  prisms_pf_configure_target(prisms_pf "Release")
 
   add_library(prisms_pf::prisms_pf_debug ALIAS prisms_pf_debug)
-  add_library(prisms_pf::prisms_pf_release ALIAS prisms_pf_release)
+  add_library(prisms_pf::prisms_pf ALIAS prisms_pf)
 
   set(
     PRISMS_PF_TARGETS
     prisms_pf_debug
-    prisms_pf_release
+    prisms_pf
   )
-elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  add_library(prisms_pf_debug)
-  prisms_pf_configure_target(prisms_pf_debug "Debug")
-  add_library(prisms_pf::prisms_pf ALIAS prisms_pf_debug)
-  add_library(prisms_pf::prisms_pf_debug ALIAS prisms_pf_debug)
-  set(PRISMS_PF_TARGETS prisms_pf_debug)
-elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
-  add_library(prisms_pf_release)
-  prisms_pf_configure_target(prisms_pf_release "Release")
-  add_library(prisms_pf::prisms_pf ALIAS prisms_pf_release)
-  add_library(prisms_pf::prisms_pf_release ALIAS prisms_pf_release)
-  set(PRISMS_PF_TARGETS prisms_pf_release)
+else()
+  add_library(prisms_pf)
+  prisms_pf_configure_target(prisms_pf ${CMAKE_BUILD_TYPE})
+  add_library(prisms_pf::prisms_pf ALIAS prisms_pf)
+  set(PRISMS_PF_TARGETS prisms_pf)
 endif()
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,16 @@ cmake_policy(VERSION 3.25)
 
 # Prohibit in-source build
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
-  message(FATAL_ERROR "In-source build prohibited. Use a separate build directory.")
+  message(
+    FATAL_ERROR
+    "In-source build prohibited. \n"
+    "Use a separate build directory with:\n  cmake -B build"
+  )
+endif()
+
+# Set the build type to DebugRelease if unspecified
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "DebugRelease" CACHE STRING "Build type" FORCE)
 endif()
 
 # Project declaration, language, and version
@@ -319,11 +328,6 @@ if(PRISMS_PF_WITH_CALIPER)
 endif()
 
 # TODO: Add VTK
-
-# Set the build type to DebugRelease if unspecified
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "DebugRelease" CACHE STRING "Build type" FORCE)
-endif()
 
 # FetchCotent MakeAvailable for the other vendored dependencies
 set(PRISMS_PF_VENDORED_PACKAGES libassert)

--- a/applications/allen_cahn/explicit/CMakeLists.txt
+++ b/applications/allen_cahn/explicit/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/allen_cahn/implicit/CMakeLists.txt
+++ b/applications/allen_cahn/implicit/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/alloy_solidification/CMakeLists.txt
+++ b/applications/alloy_solidification/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/blank/CMakeLists.txt
+++ b/applications/blank/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/cahn_hilliard/explicit/CMakeLists.txt
+++ b/applications/cahn_hilliard/explicit/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/cahn_hilliard/implicit/CMakeLists.txt
+++ b/applications/cahn_hilliard/implicit/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/coupled_allen_cahn_cahn_hilliard/CMakeLists.txt
+++ b/applications/coupled_allen_cahn_cahn_hilliard/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/laplace/CMakeLists.txt
+++ b/applications/laplace/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/mechanics/boundary_value_problem/CMakeLists.txt
+++ b/applications/mechanics/boundary_value_problem/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/mechanics/eshelby_inclusion/CMakeLists.txt
+++ b/applications/mechanics/eshelby_inclusion/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/nucleation/CMakeLists.txt
+++ b/applications/nucleation/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/pfhub_benchmarks/1/a/CMakeLists.txt
+++ b/applications/pfhub_benchmarks/1/a/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/applications/pfhub_benchmarks/6/a/CMakeLists.txt
+++ b/applications/pfhub_benchmarks/6/a/CMakeLists.txt
@@ -62,9 +62,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
   ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/tests/regression_tests/heat/CMakeLists.txt
+++ b/tests/regression_tests/heat/CMakeLists.txt
@@ -51,9 +51,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
-  main
+  ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )

--- a/tests/regression_tests/prismspf_3_6/CMakeLists.txt
+++ b/tests/regression_tests/prismspf_3_6/CMakeLists.txt
@@ -51,9 +51,12 @@ set_target_properties(
 )
 
 # Link PRISMS-PF
+# If we're in Debug configuration and PRISMS_PF_BUILD_TYPE is DebugRelease, link to the prisms_pf_debug target,
+# which is only available in prisms_pf DebugRelease configuration.
+# Otherwise link to the prisms_pf target, which may be debug or release
 target_link_libraries(
-  main
+  ${APPLICATION_NAME}
   PRIVATE
-    $<$<CONFIG:Debug>:PRISMS-PF::prisms_pf_debug>
-    $<$<CONFIG:Release>:PRISMS-PF::prisms_pf_release>
+    $<IF:$<AND:$<CONFIG:Debug>,$<STREQUAL:${PRISMS_PF_BUILD_TYPE},DebugRelease>>,PRISMS-PF::prisms_pf_debug,
+    PRISMS-PF::prisms_pf>
 )


### PR DESCRIPTION
In Debug or Release, only generate the terget "prisms_pf".
In DebugRelease, generate "prisms_pf" as the release target and "prisms_pf_debug" as the debug target.
Linking to target "prisms_pf" is now always valid.
In curated applications, always link to "prisms_pf" (which may be debug or release) unless the app config is Debug and prisms_pf_debug is available (compiled with DebugRelease).
closes #1073 