### PR TITLE
Version selector update

### DIFF
--- a/contrib/utilities/update_doc_default_version.sh
+++ b/contrib/utilities/update_doc_default_version.sh
@@ -9,7 +9,7 @@
 # ./contrib/utilities/update_doc_version_selector.sh FILE_PATH
 #
 
-REMOTE="upstream"
+REMOTE="origin"
 BRANCH="gh-pages"
 FILE_PATH="$1"
 

--- a/contrib/utilities/update_doc_default_version.sh
+++ b/contrib/utilities/update_doc_default_version.sh
@@ -9,24 +9,39 @@
 # ./contrib/utilities/update_doc_version_selector.sh FILE_PATH
 #
 
+REMOTE="upstream"
+BRANCH="gh-pages"
 FILE_PATH="$1"
 
-# Grab the latest version from the config.h file
-config_h="${1%doc/}include/prismspf/config.h"
-latest_version=$(sed -n 's/^#define PRISMS_PF_VERSION "\(.*\)"/\1/p' "$config_h" | tr -d ' \n')
-echo "Latest version found: $latest_version"
+# Find the files in the doxygen folder of the remote branch
+git fetch "$REMOTE" "$BRANCH"
+dirs=$(git ls-tree --name-only -d "$REMOTE/$BRANCH":doxygen | sort -rV)
+echo "Found directories under doxygen/:"
+echo "$dirs"
+echo ""
+
+# Get the most recent git tag
+latest_tag=$(git describe --tags --abbrev=0)
+latest_tag=${latest_tag#v}
+echo "Latest tag: $latest_tag"
+
+# Check that the folder exists on the remote branch (gh-pages)
+if ! echo "$dirs" | grep -Fxq "${latest_tag}"; then
+  echo "Error: '${latest_tag}' does not exist under doxygen/ on $REMOTE/$BRANCH"
+  exit 1
+fi
 
 # Create HTML
-cat << EOF > $FILE_PATH/index.html
+cat <<EOF >$FILE_PATH/index.html
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=$latest_version/index.html">
+    <meta http-equiv="refresh" content="0; url=$latest_tag/index.html">
     <title>Redirecting...</title>
 </head>
 <body>
-    <p>If you are not redirected automatically, <a href="$latest_version/index.html">click here</a>.</p>
+    <p>If you are not redirected automatically, <a href="$latest_tag/index.html">click here</a>.</p>
 </body>
 </html>
 EOF

--- a/contrib/utilities/update_doc_version_selector.sh
+++ b/contrib/utilities/update_doc_version_selector.sh
@@ -24,7 +24,7 @@ echo ""
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 echo "Current branch: $current_branch"
 
-# Add the latest version to the top of the list if it's not already there
+# Add the branch to the top of the list if it's not already there
 if ! echo "$dirs" | grep -q "^$current_branch$"; then
   dirs="$current_branch"$'\n'"$dirs"
 fi

--- a/contrib/utilities/update_doc_version_selector.sh
+++ b/contrib/utilities/update_doc_version_selector.sh
@@ -9,7 +9,7 @@
 # ./contrib/utilities/update_doc_version_selector.sh FILE_PATH
 #
 
-REMOTE="upstream"
+REMOTE="origin"
 BRANCH="gh-pages"
 FILE_PATH="$1"
 

--- a/contrib/utilities/update_doc_version_selector.sh
+++ b/contrib/utilities/update_doc_version_selector.sh
@@ -9,7 +9,7 @@
 # ./contrib/utilities/update_doc_version_selector.sh FILE_PATH
 #
 
-REMOTE="origin"
+REMOTE="upstream"
 BRANCH="gh-pages"
 FILE_PATH="$1"
 
@@ -20,28 +20,27 @@ echo "Found directories under doxygen/:"
 echo "$dirs"
 echo ""
 
-# Grab the latest version from the config.h file
-config_h="${1%doc/}include/prismspf/config.h"
-latest_version=$(sed -n 's/^#define PRISMS_PF_VERSION "\(.*\)"/\1/p' "$config_h" | tr -d ' \n')
-echo "Latest version found: $latest_version"
+# Get the current git branch
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+echo "Current branch: $current_branch"
 
 # Add the latest version to the top of the list if it's not already there
-if ! echo "$dirs" | grep -q "^$latest_version$"; then
-	dirs="$latest_version"$'\n'"$dirs"
+if ! echo "$dirs" | grep -q "^$current_branch$"; then
+  dirs="$current_branch"$'\n'"$dirs"
 fi
 echo "Final list of versions:"
 echo "$dirs"
 echo ""
 
 # Create HTML
-echo '<select id="versionSelector">' > $FILE_PATH/version_selector.html
+echo '<select id="versionSelector">' >$FILE_PATH/version_selector.html
 for dir in $dirs; do
-	if [[ "$(basename "$dir")" != .* ]]; then
-		version=$(basename "$dir")
-		echo "    <option value=\"$version\">$version</option>" >> $FILE_PATH/version_selector.html
-	fi
+  if [[ "$(basename "$dir")" != .* ]]; then
+    version=$(basename "$dir")
+    echo "    <option value=\"$version\">$version</option>" >>$FILE_PATH/version_selector.html
+  fi
 done
-echo '</select>' >> $FILE_PATH/version_selector.html
+echo '</select>' >>$FILE_PATH/version_selector.html
 
 echo "Done"
 exit 0

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -23,7 +23,7 @@ set(PRISMS_PF_DOXYGEN_INPUT ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/Doxyfile)
 set(PRISMS_PF_DOXYGEN_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/doxygen/Doxyfile.out)
 
 # The directory where the documentation will be generated
-set(DOXYGEN_HTML_OUTPUT "${PRISMS_PF_VERSION}")
+set(DOXYGEN_HTML_OUTPUT "${PRISMS_PF_GIT_BRANCH}")
 set(DOXYGEN_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 # Copy input to output

--- a/doc/doxygen/main/main.h
+++ b/doc/doxygen/main/main.h
@@ -1,8 +1,5 @@
 /** \mainpage PRISMS-PF
 
-\warning This is the documentation for v4.0.0, which is still actively under development.
-Use the version selector to switch to v3.0.0 for a stable version.
-
 \warning When updating your applications to newer versions of PRISMS-PF make sure to
 remove all CMake files before trying to configure and compile!
 

--- a/doc/doxygen/tutorial/tutorial.h
+++ b/doc/doxygen/tutorial/tutorial.h
@@ -163,7 +163,7 @@ cmake --build build/docs --target doc -j <nprocs>
 Once the build is complete you can visualize the local documentation by navigating to the
 doxygen folder in the build directory and starting a python HTTP server.
 @code
-cd build/docs/doc/4.0.0
+cd build/docs/doc/<branch_name>
 python3 -m http.server 8000
 @endcode
 You can open the `http://localhost:8000/` on whatever web browser you use.


### PR DESCRIPTION
Okay a few updates here:
- The version selector defaults to the latest tag
- The docs command makes a folder with the current branch name rather than version. This will create a master version of the current docs
- When releasing a new tag we will have to manually update the master folder to whatever the tag is

Closes #1261